### PR TITLE
Publish pages with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+env:
+    global:
+        - secure: "QEBHmZVWTO4vERo1/2iCGuMC1TZPF0Yfic0gvZ+ogEPfU0NhlZ2mdXv3w0BgWTNkNKaCorG/7bZAtbERKSveA5Ftrk+a6zPUBprseljl6cpkmHA9+FNWRoAYl/vyythS3igjmz0M4OuFFNnk0y1UZkuXCYyHhpvjAR+h7KymHpA="
+        - secure: "hDsT55eRQ5dRpyHwoFKCZJ1Q1IB92T8h83uRJpLMuBTJU4gaBBlsI3Gw9sr8zs86zotUclNGYD1ljiDmzk3vp+wYznJ+5P1yr3nmlYrjZTyQOF1ruFo8cVzqyBaP0ezjkX8PVe1popDjQvaP/LWoh3uVarrbMvCG0vtYw3B/K00="
+        - secure: "UJ+ZTojcC+xz0kZm2sQNtIR+Mxj0INzcoNAhJBli0IY1AoN1BohAlaKRWIjqw1oJxlzQRITEBUqRNph6fdGbXgMpqPE3wv/CIPeRJ6KOwWCOOrCgDuqJcqA1ZrSKuR9IEHV5F1U3/8B5iys7bdNx9WGL7PKhw3utW+qsFO6QQbc="
+
+before_script:
+    - git config --global user.email $GIT_EMAIL
+    - git config --global user.name $GIT_NAME
+
+install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq ruby
+    - sudo apt-get install -qq xsltproc fop
+    - gem install jekyll
+
+script:
+    - git clone "https://${GH_TOKEN}@github.com/${GIT_NAME}/cf-convention.github.io.git"
+    - cd cf-convention.github
+    # Should we build cf-conventions-1.6 too?
+    - cd Data/cf-conventions/cf-conventions-1.7
+    - mkdir docbooktmp
+    - make
+    - git commit build -m "Auto-generated HTML"
+    - cd ../../..
+    - jekyll build
+    # NOTE: All this could eventually become a generate.sh script.
+
+after_success:
+    # Publish it!
+    - git push --force


### PR DESCRIPTION
@rsignell-usgs raised this issue in the mailing list.  We can use travis to generate the HTML and publish the pages automatically.  This PR makes the "merge action"  also a "Publish page step."

There are a few things to do in this PR:
- Activate travis for cf-convention.github.io
- Add a GitHub Token
- Check if the pushing step will work once the Token is in place

Only someone with admin rights can do those steps.