### PR TITLE
Do not push to "${GIT_NAME}"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,26 @@
+branches:
+    only:
+        - master
+
 env:
     global:
         - secure: "LY/9M98qx113HEAH6DbY8J5bpYYp3ElUWhcKWqYMQ9JD+1dshEEwiWh0PmY/krcLt/v2fzSFy22XmmjbOThkjG65UdpHSDdbnricesDmi0kWdd9gsBKhQWkur3sWKtL8TPdJAXXKD0iO9qKsDbbbKmNdmZtxsCqQWn3gpjbRIeo="
         - secure: "Ln9TGZ7PN5KYyrbC82w4V6d+9XI/5g+bOYZ0/kHhh/hDI57odiotgIDG9WxPCB8LGF2KCXyxbRWkCtKe3Bh16wrCFBBzH8ojIRzEtP1UznRXyKIS/mWGIsSLzIDNWpBFhMBpzwgc6ltgLVhuXQv8f6lkgeUZq6fwkf4sQ6BT8JE="
-        - secure: "YIVjXjLNrxbNbzjtDj78vAE4OILjQa3UQGlrEoLz2LqjH0kcgMNLPno+gqPh6ePB5QVO74A9khJMnXnjiJOF3nkw368FLvEE9XeJ0LVDlfPWt3VtTN5XAtFDOoxnJ1floLZjdbzDNNBR5bi+xOXu7lri7rFfTQhE20DNPaEOp6U="
-        - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer“
+        - secure: ""
+
 before_script:
     - git config --global user.email $GIT_EMAIL
     - git config --global user.name $GIT_NAME
-    
-# branch whitelist
-branches:
-    only:
-        - master
-        
-language: ruby
-
-rvm:
-    - 2.1
+    - git config --global push.default simple
 
 install:
-     - sudo apt-get update -qq
-#    - sudo apt-get install -qq ruby
-     - sudo apt-get install -qq xsltproc fop
-     - gem install jekyll
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq xsltproc fop
 
 script:
-    - git clone "https://${GH_TOKEN}@github.com/${GIT_NAME}/cf-convention.github.io.git"
-    - cd cf-convention.github.io
-    # Should we build cf-conventions-1.6 too?
-    - cd Data/cf-conventions/cf-conventions-1.7
-    - mkdir docbooktmp
-    - make
-    - git commit build -m "Auto-generated HTML"
-    - cd ../../..
-    - travis_retry jekyll build
+    - git clone https://${GH_TOKEN}@github.com/cf-convention/cf-convention.github.io.git pages > /dev/null 2>&1
+    - cd pages
+    - bash generate.sh
 
 after_success:
-    # Publish it!
-    - git push origin master
-    
-exclude: [vendor]
+    - git push --force --quiet > /dev/null 2>&1

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Should we build cf-conventions-1.6 too?
+cd Data/cf-conventions/cf-conventions-1.7
+mkdir docbooktmp
+make
+git commit build -m "Auto-generated HTML"


### PR DESCRIPTION
@rsignell-usgs 

- We do not need `NOKOGIRI_USE_SYSTEM_LIBRARIES=true`  because we do not run `html-proofer`.
- No need to define ruby nor to install Jekyll and its gems because we do not need to run Jekyll (we only need to create the main document)
- The `exclude: [vendor]` should go into the jekyll `_config.yml` and not in the `.travis.yml` file.  However, we will need that only if build the whole site with Jekyll on Travis-CI.

Note that we could build the whole site and test it.  However, that is beyond the scope of an auto-publish setup and I believe we should leave that to another PR.