### PR TITLE
draft comment and ordering

### DIFF
--- a/documents.md
+++ b/documents.md
@@ -10,17 +10,21 @@ group: "navigation"
   <div class="col-md-4">
     <h2>CF Conventions</h2>
     <p>
-      <h4>CF 1.8-draft</h4>
-      <a href="/cf-conventions/cf-conventions.html">Single HTML</a>
-      &nbsp;
-      <a href="/cf-conventions/cf-conventions.pdf">PDF</a>
-      &nbsp;
       
       <h4>CF 1.7</h4>
       <a href="Data/cf-conventions/cf-conventions-1.7/cf-conventions.html">Single HTML</a>
       &nbsp;
       <a href="Data/cf-conventions/cf-conventions-1.7/cf-conventions.pdf">PDF</a>
       &nbsp;
+
+      <h4>CF 1.8-draft</h4>
+      <a href="/cf-conventions/cf-conventions.html">Single HTML</a>
+      &nbsp;
+      <a href="/cf-conventions/cf-conventions.pdf">PDF</a>
+      &nbsp;
+
+      <br>
+      This is the editors' draft and contains accepted changes that are not yet part of a release.  This draft is subject to further change.
 
       <h4>CF 1.7.2 (obsolete)</h4>
       <a href="Data/cf-conventions/cf-conventions-1.7/build/cf-conventions.html">Single HTML (DocBook)</a> &nbsp;

--- a/latest.md
+++ b/latest.md
@@ -10,7 +10,7 @@ title: Latest
 <table>
 <tr>
   <th width="300px"> Most Recent Release (v1.7) <br /> &nbsp;</th>
-  <th width="300px"> Current Working Draft (v1.8) <br /> &nbsp;</th> 
+  <th width="300px"> Current Working Draft (v1.8-draft) <br /> &nbsp;</th> 
 </tr>
 <tr>
   <td>
@@ -23,6 +23,7 @@ title: Latest
     <ul>
       <li> <a href="/cf-conventions/cf-conventions.html">Single HTML</a> </li> <br />
       <li> <a href="/cf-conventions/cf-conventions.pdf">PDF</a> </li> <br />
+      <li> This is the editors' draft and contains accepted changes that are not yet part of a release.  This draft is subject to further change. </li> <br />
     </ul>
   </td>
 </tr>


### PR DESCRIPTION
At the CF meeting in Reading this week we discussed the CF homepage and the promenance of the "editors' draft" within the website.

Following that discussion, this change adds a caveat in text explaining that this is the "editor's draft".

The change also alters the order or documents within the documents page, such that the latest release: 1.7, appears as the top document.

@JonathanGregory 