### PR TITLE
Update "Latest" standard table link

### DIFF
--- a/latest.md
+++ b/latest.md
@@ -28,9 +28,9 @@ title: Latest
 </tr>
 </table>
 
-## Standard Names Table (v27)
+## Standard Names Table (v55)
 
-* <a href="Data/cf-standard-names/27/build/cf-standard-name-table.html">HTML</a>
+* <a href="Data/cf-standard-names/current/build/cf-standard-name-table.html">HTML</a>
 
 ## Standardized Region Names
 


### PR DESCRIPTION
Addresses issue #57 - update standard name link to always point to current table.  Edit header to indicate current table is version 55 as of this edit