### PR TITLE
in faq updated url to area type table; fixed #75

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -301,7 +301,7 @@ The situation is complicated in the case of a climatology, where the total range
 
 ### My variable depends on the type of surface. How can I specify the surface type?
 
-CF maintains a vocabulary specifically for specifying surface and area types; it is available on the CF site as the [Area Type Table](http://cfconventions.org/Data/cf-standard-names/docs/area-type-table.html), and can also be accessed as a [controlled vocabulary](http://mmisw.org/ont/cf/areatype).
+CF maintains a vocabulary specifically for specifying surface and area types; it is available on the CF site as the [Area Type Table](http://cfconventions.org/Data/area-type-table/current/build/area-type-table.html), and can also be accessed as a [controlled vocabulary](http://mmisw.org/ont/cf/areatype).
 
 Terms from this vocabulary may be used as specified in the CF Convention [section 7.3.3 Statistics applying to portions of cells](http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#statistics-applying-portions). However, it is also possible to describe a data variable by using a named quantity as a coordinate variable, and the area_type is often needed for such a purpose. The area_type can be attached as a dimensioned coordinate variable, or as a scalar coordinate.
 


### PR DESCRIPTION
In the answer to question [My variable depends on the type of surface. How can I specify the surface type?](http://cfconventions.org/faq.html#surface_type_coordinate) there is a link to the Area Type Table. The link is broken. It directs to 

* http://cfconventions.org/Data/cf-standard-names/docs/area-type-table.html 

but should direct to 

* http://cfconventions.org/Data/area-type-table/current/build/area-type-table.html