### PR TITLE
Add Meetings pages for annual workshops and other CF related meetings.

### DIFF
--- a/Meetings/2018-Workshop.md
+++ b/Meetings/2018-Workshop.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: 2018 CF Workshop
+---
+
+# 2018 netCDF-CF Workshop
+ 
+This two day workshop took place on 19-20 June 2018 and was hosted by
+the [National Centre for Atmospheric Science][ncas] at the University of
+Reading, UK.
+
+## CF Data Model Review and Update
+
+Discussion
+* 
+
+[ncas]: https://www.ncas.ac.uk/en/

--- a/Meetings/2019-Workshop.md
+++ b/Meetings/2019-Workshop.md
@@ -1,0 +1,51 @@
+---
+layout: default
+title: 2019 CF Workshop
+---
+
+# 2018 netCDF-CF Workshop
+ 
+This one day workshop took place on 16 & 17 July 2019
+as four sessions of the 2019 [ESIP][esip] [Summer Meeting][esip2019sm] in Tacoma, WA.
+
+## Agenda
+[Session 1][Session1]: Welcome
+* Introductions, Workshop Plans, and Goals (Jessica Hausmann)
+* Summary of 2018 workshop - discussions, decisions, and status (Ethan Davis)
+* Review recent discussions of CF Governance and Process (Daniel Lee)
+[Session 2][Session2]: Governance and evolution
+* CF Governance, Roles, and Process
+* GitHub process - where we are and where we want to be
+* Way forward
+[Session 3][Session3]: Recent and Current Proposals
+* Welcome
+* Groups (Daniel Lee)
+* UGRID (Rich Signell)
+* Satellite Swath (Aleksandar Jelenak)
+* Linked Data with netCDF
+* Representing uncertainties (Ken Kehoe)
+* External variables (David Hassell)
+* Geomeries (Tim Whiteaker)
+* DOI Attribute (DOI of the data) (Guilherme Castelao)
+* Requirements related to specific standard names (Martin Juckes)
+* Bibliography and PDF improvements (Klaus Zimmermann)
+* Clarification of time coordinate requirements (Martin Juckes)
+* Discussions and decisions
+[Session 4][Session4]: Other Business and Wrap-Up
+*  UDUNITS (Ethan Davis)
+* Calendars (Ethan Davis)
+* Leap seconds (Jim Biard)
+* CF in the cloud (Aleksandar Jelenak)
+* Next steps (Ethan Davis)
+
+## Summary and Key Decisions
+
+Discussion
+* 
+
+[esip]: https://www.esipfed.org/
+[esip2019sm]: https://2019esipsummermeeting.sched.com/
+[Session1]: https://2019esipsummermeeting.sched.com/event/PtPD/netcdf-cf-workshop-part-i
+[Session2]: https://2019esipsummermeeting.sched.com/event/PtPD/netcdf-cf-workshop-part-ii
+[Session3]: https://2019esipsummermeeting.sched.com/event/PtPD/netcdf-cf-workshop-part-iii
+[Session4]: https://2019esipsummermeeting.sched.com/event/PtPD/netcdf-cf-workshop-part-iv

--- a/Meetings/2020-Workshop.md
+++ b/Meetings/2020-Workshop.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: 2020 CF Workshop
+---
+
+# 2020 CF Workshop
+ 
+The 2020 CF Workshop will be held in Santander, Spain on 10-11 June 2020
+with a half day training event on the preceding afternoon (9 June 2020).
+It will be hosted by [University of Cantabria][UCantabria].
+
+The dates may be fixed, but the content is not.
+The broad areas we expect to cover could include:
+
+* Governance
+* Unresolved proposals for enhancements to CF
+* CF procedures (e.g. GitHub, standard names, ...)
+
+so any specific suggestions on these topics, or anything else, will be most welcome.
+
+The training event will focus on how to interact with CF systems and processes,
+such as how to use GitHub to suggest enhancements,
+and how best to get new standard names accepted.
+Again, please let us know of specific items
+that you might find useful for this part of the workshop.
+
+Many thanks, and we hope to see you there (in person or virtually)
+
+Please make suggestion or comments
+on the CF Discuss GitHub repo
+on the announcment issue ([#??](https://github.com/cf-convention/discuss/issues/??)) . 
+
+[UCantabria]: https://web.unican.es/en/

--- a/Meetings/index.md
+++ b/Meetings/index.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Meetings
+group: "navigation"
+---
+
+# CF Meetings and Workshop
+
+## Annual CF Workshops
+
+* [2020 CF Workshop][2020] - 9-11 June 2020 at University of Cantabria in Santandor, Spain
+* [2019 CF Workshop][2019] - 
+* [2018 CF Workshop][2018] - 
+ 
+[2020]: 2020-Workshop.html
+[2019]: 2019-Workshop.html
+[2018]: 2018-Workshop.html


### PR DESCRIPTION
@davidhassell and @erget  - Here's a PR for the Meetings pages we discussed in Thursday's call. For the 2020 Workshop page, I mostly just pulled the text from your draft announcement.

I made it a sub-directory (thought about sub-dirs for each year, maybe later if we need them) but I'm not sure I got the navigation stuff right. I tried to follow the patterns I found but don't have Jekyll setup to run locally so haven't tested that it will build properly. I guess Travis builds on PRs and we can see success or failure but not sure we can look at resulting pages.