### PR TITLE
Add original constitution (from white paper) and a link to it

### DIFF
--- a/constitution.adoc
+++ b/constitution.adoc
@@ -1,0 +1,163 @@
+= Terms of Reference for CF Committees and Governance Panel
+B. N. Lawrence, R. Drach, B. E. Eaton, J. M. Gregory, S. C. Hankin, R. K. Lowry, R. K. Rew, and K. E. Taylor
+From the CF white paper of 2006
+
+
+=== Constitution of the CF Governance Panel
+
+The CF Governance Panel will come into existence on 1st October 2006 and assume
+its duties and responsibilities from that date. Until that date, the original
+CF authors will have responsibility for the governance of the CF standard.
+
+The panel will initially be appointed by the WMO/WCRP Working Group on Coupled
+Modelling (WGCM) to govern the development of the CF standard on behalf of the
+user community. If the WGCM wishes to transfer or share responsibility for CF
+with another permanent committee of an international organisation, it may
+decide to do so with the agreement of both CF committees.
+
+The panel will include, but not be limited to, members of the WGCM, the
+leaders, or their nominees, of organisations contributing significant resources
+in support of CF, and the chairs of the CF committees on conventions and
+standard names.
+
+
+=== Terms of reference of the CF Governance Panel
+
+The panel will be responsible for the stewardship of CF, but will not have any
+special responsibility for or influence on the technical content of CF.
+
+The panel will ensure that its own constitution and terms of reference, those
+of the CF committees, and the aims and general principles of design of the CF
+standard are published. These may be altered by the panel only after
+appropriate public debate and with the agreement of both CF committees.
+
+The panel will promote and help integrate the use of CF across WCRP programmes,
+the broader programmes of WCRP's sponsors (ICSU, WMO, and IOC), and other
+interested communities. In particular the panel will attempt to influence
+developing metadata standards of WMO and other international organisations so
+that they accommodate the CF standard.
+
+The panel will encourage continued support of CF by benevolent organisations
+and explore additional funding mechanisms if necessary.
+
+The panel will appoint people who have nominated themselves or agreed to serve
+as members of the conventions committee and the standard names committee. In
+doing so it will have regard to the expertise and interests relevant to the
+remit of each committee and will attempt to obtain representation of a variety
+of communities and a geographical spread of members. The maximum and minimum
+numbers of members of either committee may be amended by agreement between that
+committee and the panel. The panel will ensure that the current membership of
+the two CF committees is published.
+
+
+=== Constitution of the CF committees
+
+Anyone with sufficient time, interest and expertise is qualified to serve as an
+ordinary member of the conventions committee or the standard names committee or
+both. Prospective ordinary members will nominate themselves. Before 1st October
+2006, members of the committees will be appointed by the original CF
+authors. From 1st October 2006, they will be appointed by the CF Governance
+Panel. Committee members judged by the panel to have been inactive for an
+extended period will be asked to resign. Members may choose to resign at any
+time and must retire after five years, but may be reappointed. The maximum
+number of ordinary members of each committee is sixteen and the minimum is
+four.
+
+The initial chairs of the committees will be appointed by the original CF
+authors. Whenever a vacancy arises subsequently, each committee will elect its
+own chair from among its ordinary members. The chair may resign the office at
+any time and must retire after three years, but may be reelected.
+
+Each committee will have authority and responsibility for the development of
+the aspects of the CF standard within its remit, as detailed in its terms of
+reference, having regard to the aims and general principles of design of CF. It
+will discharge its responsibility by overseeing and contributing to public
+debate on how the standard should be expanded or altered, and by deciding after
+debate whether and what changes will be made.
+
+Each committee will be assisted in its responsibility by a permanent and funded
+member of staff, who will be appointed in a manner decided by the CF Governance
+Panel, and who will be an ex-officio member and secretary of the committee. The
+manager of CF conventions will be the secretary of the conventions committee
+and the manager of CF standard names will be the secretary of the standard
+names committee. The committee will propose priorities for work by its
+secretary.
+
+Each committee will ensure that appropriate means are made available for making
+proposals and carrying out debates in a way which is visible and open to
+participation by all interested parties, and for retaining a permanent public
+record of debates and of any decisions made by the committee. It will decide
+the period of time which should be allowed between a proposal being made
+publicly and a final decision being required, and any other procedures
+necessary. These procedures should assume that community consensus will
+generally be followed in deciding for or against changes, but the committee
+will make the decision itself if no consensus is evident or the public debate
+is inconclusive. The committee may decide exceptionally to make no change
+although public consensus is in favour of a change, if it judges that the
+proposed change would be damaging to the CF standard. A committee member who
+believes this to be case for a particular proposed change should notify the
+other members of this opinion before the time arrives by which a decision must
+be made according to the rules, and may request the committee to take the
+decision itself, rather than allowing public consensus to decide. If such a
+request is not made, the secretary will decide what is the outcome of the
+public debate and will make or not make changes accordingly.
+
+A decision by the committee on changes to the CF standard within its remit or
+on any procedural matter will require a simple majority of the membership to be
+in favour.
+
+The committees may not devolve responsibility for the CF standard to other
+bodies, but they may encourage the formation of other permanent or temporary
+ad-hoc groups to debate issues and propose developments to CF.
+
+Each committee will ensure that the parts of the standard for which it is
+responsible, any supporting documents and resources, and the procedures for
+proposing and deciding changes are kept up-to-date and made publicly available.
+
+The committees may not change their constitutions or terms of reference
+themselves, but each may propose changes to be made by the CF Governance Panel.
+
+
+=== Terms of reference of the conventions committee
+
+The conventions committee will be responsible for the development of the CF
+conventions constituting the CF netCDF standard, except for the definition of
+standard names and of any other aspects of controlled vocabulary in the
+appendices to the standard that it agrees with the standard names committee
+should be within the remit of that committee.
+
+The conventions committee and standard names committee will together define the
+format of the standard name table.
+
+The conventions committee will have an interest in implementation of CF
+metadata conventions corresponding to the CF standard in other file formats and
+media apart from netCDF.
+
+The conventions committee will be responsible for the CF conformance document
+and for deciding what CF conformance means.
+
+The membership of the conventions committee should include representatives of
+those who maintain widely used software which follows the CF conventions,
+especially those which the committee regards as reference implementations.
+
+
+=== Terms of reference of the standard names committee
+
+The standard names committee will be responsible for the definition of CF
+standard names and of any other aspects of controlled vocabulary in the
+appendices to the CF netCDF standard that it agrees with the conventions
+committee should be within its remit.
+
+The standard names committee will be responsible for maintaining the standard
+name table. The standard names committee and the conventions committee will
+together define the format of the standard name table.
+
+The standard names committee will have an interest in working towards
+interoperability with other vocabulary maintainers.
+
+The standard names committee will make proposals for modification of
+conventions when it appears that names cannot be satisfactorily defined within
+the prevailing conventions.
+
+The membership of the standard names committee should include representatives
+of the various scientific user communities of the CF standard.

--- a/constitution_original.md
+++ b/constitution_original.md
@@ -1,9 +1,9 @@
-= Terms of Reference for CF Committees and Governance Panel
+# Terms of Reference for CF Committees and Governance Panel
 B. N. Lawrence, R. Drach, B. E. Eaton, J. M. Gregory, S. C. Hankin, R. K. Lowry, R. K. Rew, and K. E. Taylor
 From the CF white paper of 2006
 
 
-=== Constitution of the CF Governance Panel
+### Constitution of the CF Governance Panel
 
 The CF Governance Panel will come into existence on 1st October 2006 and assume
 its duties and responsibilities from that date. Until that date, the original
@@ -21,7 +21,7 @@ in support of CF, and the chairs of the CF committees on conventions and
 standard names.
 
 
-=== Terms of reference of the CF Governance Panel
+### Terms of reference of the CF Governance Panel
 
 The panel will be responsible for the stewardship of CF, but will not have any
 special responsibility for or influence on the technical content of CF.
@@ -50,7 +50,7 @@ committee and the panel. The panel will ensure that the current membership of
 the two CF committees is published.
 
 
-=== Constitution of the CF committees
+### Constitution of the CF committees
 
 Anyone with sufficient time, interest and expertise is qualified to serve as an
 ordinary member of the conventions committee or the standard names committee or
@@ -118,7 +118,7 @@ The committees may not change their constitutions or terms of reference
 themselves, but each may propose changes to be made by the CF Governance Panel.
 
 
-=== Terms of reference of the conventions committee
+### Terms of reference of the conventions committee
 
 The conventions committee will be responsible for the development of the CF
 conventions constituting the CF netCDF standard, except for the definition of
@@ -141,7 +141,7 @@ those who maintain widely used software which follows the CF conventions,
 especially those which the committee regards as reference implementations.
 
 
-=== Terms of reference of the standard names committee
+### Terms of reference of the standard names committee
 
 The standard names committee will be responsible for the definition of CF
 standard names and of any other aspects of controlled vocabulary in the

--- a/governance.md
+++ b/governance.md
@@ -12,7 +12,8 @@ group: "navigation"
   * Discussion about these rules can be found in the [CF mailing list archives][mail], in June and July, 2007. See messages with the subject line "proposed rules for changes to CF conventions".
   * The rules were amended in January 2016 following [CF trac ticket 146][ticket146]
 * [Rules for correcting errors in the CF documents][errors]
-* CF Governance Document  \[ [PDF][pdf], [HTML][html] \]
+* [CF constitution](./constitution.adoc)
+* CF white paper (Lawrence et al., 2006)  \[ [PDF][pdf], [HTML][html] \]
  
 ### Conventions Committee and Standard Names Committee
 


### PR DESCRIPTION
I have converted the appendix in the white paper giving the terms of reference into constitution.adoc, and made a link to it from the governance page. This is no change in content from the current arrangements. When this has been merged, I will propose the small changes from the governance panel.