### PR TITLE
Make references absolute

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,12 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Climate and Forecast Metadata also know as the CF Convention or CF Metadata" />
     <meta name="author" content="Matthew Harris (mattben)">
-    <link rel="shortcut icon" href="Data/media/images/favicon.ico">
+    <link rel="shortcut icon" href="/Data/media/images/favicon.ico">
 
     <title>{{ page.title }}</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="Data/media/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/Data/media/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
     <style>
@@ -35,7 +35,7 @@
           <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
             <span class="sr-only">Toggle navigation</span>
           </button>
-          <a class="navbar-brand" href="index.html"><img src="Data/media/images/logo.png" style="position: relative; top: -10px"/></a><a class="navbar-brand" href="index.html">CF MetaData</a>
+          <a class="navbar-brand" href="/index.html"><img src="/Data/media/images/logo.png" style="position: relative; top: -10px"/></a><a class="navbar-brand" href="/index.html">CF MetaData</a>
         </div>
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
@@ -69,8 +69,8 @@
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-    <script src="Data/media/js/bootstrap.min.js"></script>
-    <script src="Data/media/js/links.js"></script>
+    <script src="/Data/media/js/bootstrap.min.js"></script>
+    <script src="/Data/media/js/links.js"></script>
 
   </body>
 </html>


### PR DESCRIPTION
Fixes unresolved references in the meetings pages, which are a step down the tree and thus weren't finding the image and JS assets.