### PR TITLE
Improve footer and edit link to branch

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,8 +66,8 @@
 
       <footer>
       <p>
-      <a href="http://cfconventions.org/discussion.html">Contact the CF community</a>
-      <a href="{{ site.github.repository_url }}/edit/master/{{ page.path }}">Edit this page on GitHub!</a>
+      <a href="http://cfconventions.org/discussion.html">Contact the CF community</a> &bull;
+      <a href="{{ site.github.repository_url }}/edit/{{ site.github.source.branch }}/{{ page.path }}">Edit this page on GitHub!</a>
       </p>
       </footer>
     </div> <!-- /container -->


### PR DESCRIPTION

This change improve the edit link replacing ad-hoc brancho (i.e. master) with a variable representing the actual branch been published: `site.github.source.branch`

This relates to issue cf-convention/discuss#125

