### PR TITLE
Remove Conformance from navigation, because these links and informati…

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,8 +66,7 @@
 
       <footer>
       <p>
-      <a href="http://cfconventions.org/discussion.html">Contact the CF community</a>
-      <a href="{{ site.github.repository_url }}/edit/master/{{ page.path }}">Edit this page on GitHub!</a>
+      <a href="http://cfconventions.org/discussion.html">Contact the CF community</a> with questions, comments and suggestions about CF metadata or this website
       </p>
       </footer>
     </div> <!-- /container -->

--- a/about-trac.md
+++ b/about-trac.md
@@ -5,7 +5,8 @@ title: Governance
 
 ## CF Trac Website
 
-The CF Trac website can be found at [http://cf-trac.llnl.gov/trac](http://cf-trac.llnl.gov/trac).
+This page is an archive copy, kept only for historical interest, of information about the former [CF Metadata Trac](Data/trac.html) site, which itself also is now kept only as an archive. The Trac site was used until July 2018 for discussion of enhancements to the CF convention. New proposals are now [discussed in GitHub](discussion.html). The following information should be read in the past tense.
+
 
 ## How the Ticket System Works
 

--- a/conformance.md
+++ b/conformance.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Conformance
-group: "navigation"
 ---
 
 # Conformance

--- a/governance.md
+++ b/governance.md
@@ -84,4 +84,4 @@ The climate research community is indebted to the above for their magnanimous co
 [mail]: http://mailman.cgd.ucar.edu/pipermail/cf-metadata
 [html]: Data/cf-documents/cf-governance/cf2_whitepaper_final.html
 [pdf]:  Data/cf-documents/cf-governance/cf2_whitepaper_final.pdf
-[ticket146]: http://cf-trac.llnl.gov/trac/ticket/146
+[ticket146]: http://cfconventions.org/Data/Trac-tickets/146.html

--- a/index.md
+++ b/index.md
@@ -31,6 +31,7 @@ See also the links in the navigation bar at the top of this page.
 * [Latest release of CF conventions][releasedhtml]
 * [Current version of CF standard name table][currentnames]
 * Current issues: [general discussion][github_discuss] (including standard names), [conventions][github_conventions], this [website][github_website] (including governance)
+* [CF GitHub organisation][cf_github]
 * [CF FAQ][q8]
 * [List of software for working with CF](software.md)
 * [Paper][cfdmpaper] describing the CF data model and reference software
@@ -59,3 +60,4 @@ See also the links in the navigation bar at the top of this page.
 [github_discuss]: https://github.com/cf-convention/discuss/issues
 [github_conventions]: https://github.com/cf-convention/cf-conventions/issues
 [github_website]: https://github.com/cf-convention/cf-convention.github.io/issues
+[cf_github]: https://github.com/cf-convention

--- a/standard-names.md
+++ b/standard-names.md
@@ -189,8 +189,8 @@ group: "navigation"
 
   <h5><b>Discussion</b></h5>
 
-  <a href="http://cfeditor.ceda.ac.uk/proposals/1?status=active&namefilter=&proposerfilter=&descfilter=&filter+and+display=filter)">Current status of proposals for new standard names</a> <br>
-  <a href="http://cfeditor.ceda.ac.uk/proposals/1?status=inactive&namefilter=&proposerfilter=&descfilter=&filter+and+display=filter)">Archive of resolved proposals for new standard names (from March 2011 onwards)</a> <br>
+  <a href="http://cfeditor.ceda.ac.uk/proposals/1?status=active&namefilter=&proposerfilter=&descfilter=&filter+and+display=filter">Current proposals for new standard names</a> <br>
+  <a href="http://cfeditor.ceda.ac.uk/proposals/1?status=inactive&namefilter=&proposerfilter=&descfilter=&filter+and+display=filter">Resolved proposals for new standard names (from March 2011 onwards)</a> <br>
 
 <h4><b>Area Type Table (v10, 23 June 2020)</b></h4>
   <a href="Data/area-type-table/10/build/area-type-table.html">HTML</a>&nbsp;


### PR DESCRIPTION
Remove Conformance from navigation, because these links and information have been included in the Conventions page.
Change the link to CF trac ticket 146 in the Governance page to point to the archive of Trac in GitHub.
Modify the start of the "About Trac" page to explain that it is an archive copy, and point to the archive of Trac.
Correct the links to the cfeditor in the Standard Names page, and modify the text to be consistent with the Discussion page.
Add a quick link to CF GitHub on the home page.