### PR TITLE
Changing affiliation on governance page

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -47,7 +47,7 @@ CF Governance Panel meeting [minutes](Governance/GovPanel/meeting-minutes.md)
 ### Information Management and Support Team
 
 * Martin Desruisseaux (Geomatys)
-* Fran Eggleton (CEDA)
+* Fran Eggleton (UK Met Office)
 * John Graybeal (Stanford University)
 * David Hassell (University of Reading)
 * Rosalyn Hatcher (University of Reading)


### PR DESCRIPTION
Changing affiliation in the Information Management and Support Team section of the Governance page as per https://github.com/cf-convention/discuss/issues/138