### PR TITLE
modify mailing list archive on discussion page

### DIFF
--- a/discussion.md
+++ b/discussion.md
@@ -33,16 +33,14 @@ using [GitHub issues][github_issues].
 No registration with CF is required to contribute; all that is needed
 is a freely available [GitHub account][github].
 
-Before the CF community migrated to GitHub,
-general and standard-name discussion took place on the
-[cf-metadata mailing list][archives], and enhancements
-to the conventions were proposed
-on the [CF Metadata Trac](Data/trac.html) site.
-
+Before the CF community migrated to GitHub, general and standard-name
+discussion took place on the [cf-metadata mailing list][archives], and
+enhancements to the conventions were proposed on the [CF Metadata
+Trac](Data/trac.html) site.
 
 ### Archive links
 
-* [cf-metadata Mailing List Archives][archives] (until December 2019)
+* cf-metadata mailing list archive [copy on GitHub][archives] or [original at NCAR][NCAR_archives] (until December 2019)
 * [Resolved proposals for new standard names][proposals] (from March 2011 onwards)
 * [CF Metadata Trac](Data/trac.html) (until July 2018)
 * [About CF Metadata Trac][about]
@@ -55,7 +53,8 @@ on the [CF Metadata Trac](Data/trac.html) site.
 [trac]: Data/trac.html
 [about]: about-trac.html
 [mail]: http://mailman.cgd.ucar.edu/mailman/listinfo/cf-metadata
-[archives]: http://mailman.cgd.ucar.edu/pipermail/cf-metadata/
+[archives]: https://cfconventions.org/mailing-list-archive/Data/
+[NCAR_archives]: https://mailman.cgd.ucar.edu/pipermail/cf-metadata/
 [current]: http://cfeditor.ceda.ac.uk/proposals/1?status=active&namefilter=&proposerfilter=&descfilter=&filter+and+display=filter
 [proposals]: http://cfeditor.ceda.ac.uk/proposals/1?status=inactive&namefilter=&proposerfilter=&descfilter=&filter+and+display=filter
 [github_issues]: https://guides.github.com/features/issues

--- a/discussion.md
+++ b/discussion.md
@@ -39,6 +39,7 @@ general and standard-name discussion took place on the
 to the conventions were proposed
 on the [CF Metadata Trac](Data/trac.html) site.
 
+
 ### Archive links
 
 * cf-metadata mailing list archive [copy on GitHub][archives] or [original at NCAR][NCAR_archives] (until December 2019)

--- a/discussion.md
+++ b/discussion.md
@@ -33,10 +33,11 @@ using [GitHub issues][github_issues].
 No registration with CF is required to contribute; all that is needed
 is a freely available [GitHub account][github].
 
-Before the CF community migrated to GitHub, general and standard-name
-discussion took place on the [cf-metadata mailing list][archives], and
-enhancements to the conventions were proposed on the [CF Metadata
-Trac](Data/trac.html) site.
+Before the CF community migrated to GitHub,
+general and standard-name discussion took place on the
+[cf-metadata mailing list][archives], and enhancements
+to the conventions were proposed
+on the [CF Metadata Trac](Data/trac.html) site.
 
 ### Archive links
 


### PR DESCRIPTION
Link GitHub archive and correct link to NCAR archive to use https