### PR TITLE
Fix link errors for v80 in vocabularies.md

### DIFF
--- a/vocabularies.md
+++ b/vocabularies.md
@@ -13,7 +13,7 @@ group: "navigation"
 
   <h5><b>Previous Versions (HTML)</b></h5>
     N.B. For technical reasons, no standard name table was published with version number 38.<br>
-    <a href="Data/cf-standard-names/79/build/cf-standard-name-table.html">v80</a> &nbsp;
+    <a href="Data/cf-standard-names/80/build/cf-standard-name-table.html">v80</a> &nbsp;
     <a href="Data/cf-standard-names/79/build/cf-standard-name-table.html">v79</a> &nbsp;
     <a href="Data/cf-standard-names/78/build/cf-standard-name-table.html">v78</a> &nbsp;
     <a href="Data/cf-standard-names/77/build/cf-standard-name-table.html">v77</a> &nbsp;
@@ -95,7 +95,7 @@ group: "navigation"
 
   <h5><b>Previous Versions (XML)</b></h5>
     N.B. For technical reasons, no standard name table was published with version number 38.<br>
-    <a href="Data/cf-standard-names/79/src/cf-standard-name-table.xml">v80</a> &nbsp;
+    <a href="Data/cf-standard-names/80/src/cf-standard-name-table.xml">v80</a> &nbsp;
     <a href="Data/cf-standard-names/79/src/cf-standard-name-table.xml">v79</a> &nbsp;
     <a href="Data/cf-standard-names/78/src/cf-standard-name-table.xml">v78</a> &nbsp;
     <a href="Data/cf-standard-names/77/src/cf-standard-name-table.xml">v77</a> &nbsp;
@@ -176,7 +176,7 @@ group: "navigation"
     <a href="Data/cf-standard-names/1/src/cf-standard-name-table.xml">v1</a> &nbsp;
 
 <h5>Previous Versions (Keyword Centred List)</h5>
-      <a href="Data/cf-standard-names/79/build/kwic_index_for_cf_standard_names.html">v80</a>  &nbsp;
+      <a href="Data/cf-standard-names/80/build/kwic_index_for_cf_standard_names.html">v80</a>  &nbsp;
       <a href="Data/cf-standard-names/79/build/kwic_index_for_cf_standard_names.html">v79</a>  &nbsp;
       <a href="Data/cf-standard-names/78/build/kwic_index_for_cf_standard_names.html">v78</a>  &nbsp;
       <a href="Data/cf-standard-names/77/build/kwic_index_for_cf_standard_names.html">v77</a>  &nbsp;


### PR DESCRIPTION
Links for v80 were wrong (pointed to v79 instead).