### PR TITLE
Update to `actions/checkout@v3`

### DIFF
--- a/.github/workflows/check_jekyll_build.yml
+++ b/.github/workflows/check_jekyll_build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build with Jekyll
         uses: nigelbritton/jekyll-build-action@v1.1

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check links
         uses: lycheeverse/lychee-action@v1.8.0
         with:


### PR DESCRIPTION
Fixes #424 

With  `actions/checkout@v2` we are getting "node12" deprecation warnings. According to https://github.com/actions/checkoutissues/1047 we need to update to `actions/checkout@v3`, which is what this PR does. With this change the build looks fine for me locally, and the deprecation errors have gone.