### PR TITLE
Link to XSD schema file on the vocabularies web page

### DIFF
--- a/vocabularies.md
+++ b/vocabularies.md
@@ -211,6 +211,7 @@ group: "navigation"
     <a href="Data/cf-standard-names/docs/guidelines.html">Guidelines</a> for Construction of CF Standard Names<br>
     List of<a href="Data/cf-standard-names/docs/standard-name-contributors.html"> contributors</a> to CF Standard Names<br>
     <a href="standard_name_rules.html">Rules</a> for making changes to the CF vocabularies
+    <a href="Data/schema-files/cf-standard-name-table-2.0.xsd">Schema file</a> for the Standard name table XML files (version 1 -- current)
 
   <h5><b>Discussion</b></h5>
 

--- a/vocabularies.md
+++ b/vocabularies.md
@@ -210,8 +210,8 @@ group: "navigation"
   <h5><b>Documents</b></h5>
     <a href="Data/cf-standard-names/docs/guidelines.html">Guidelines</a> for Construction of CF Standard Names<br>
     List of<a href="Data/cf-standard-names/docs/standard-name-contributors.html"> contributors</a> to CF Standard Names<br>
-    <a href="standard_name_rules.html">Rules</a> for making changes to the CF vocabularies
-    <a href="Data/schema-files/cf-standard-name-table-2.0.xsd">Schema file</a> for the Standard name table XML files (version 1 -- current)
+    <a href="standard_name_rules.html">Rules</a> for making changes to the CF vocabularies<br>
+    <a href="Data/schema-files/cf-standard-name-table-2.0.xsd">Schema file</a> for all versions of the Standard Name Table XML files
 
   <h5><b>Discussion</b></h5>
 


### PR DESCRIPTION
This PR adds a link to the XSD schema file in `vocabularies.html` page, i.e.  implements issue https://github.com/cf-convention/cf-convention.github.io/issues/469.

~~**This PR must be merged after PR https://github.com/cf-convention/cf-convention.github.io/pull/468.**~~ That PR is now merged.