### PR TITLE
Added the 2024 CF Workshop page

### DIFF
--- a/Meetings/2024-Workshop.md
+++ b/Meetings/2024-Workshop.md
@@ -23,7 +23,7 @@ Part 2 will follow the familiar format of our usual annual meeting.
 
 ## Documents
 
-All the presentations and notes for the plenary and breakout sessions will be available in this [Google Drive folder]() (No yet availiable).
+All the presentations and notes for the plenary and breakout sessions will be available in this [Google Drive folder]() (Not yet available).
 
 ## Agenda
 **TO BE [DISCUSSED][ISSUE] AND COMPLETED**
@@ -52,7 +52,7 @@ Participants should review the [CF Code of Conduct][CoC].
 ## The organising committee
 * Alison Pamment
 * David Hassell
-* Elli Fisher
+* Ellie Fisher
 * Ethan Davis
 * Lars Bärring
 * **Your name here, [there's still room for more help!][ISSUE]**

--- a/Meetings/2024-Workshop.md
+++ b/Meetings/2024-Workshop.md
@@ -1,0 +1,61 @@
+---
+layout: default
+title: 2024 CF Workshop
+---
+
+# 2024 CF Workshop
+
+The 2024 CF workshop will be held at SMHI, Norrköping, Sweden (and online) from Tuesday 17th to Friday 20th September 2024.
+
+The meeting will be divided into two parts, and participants may choose to attend the first two days of the programme, the last two days, or the whole meeting, according to their own interests and availability:
+
+ - **Part 1 (17-18 September 2024): Engaging the cross-domain CF community to gather user needs and develop a high-level CF roadmap.**
+ - **Part 2 (19-20 September 2024): Detailed CF development including hackathon sessions.**
+
+The plan for Part 1 of the workshop is to invite speakers from a broad range of CF users and potential users, for example, representatives of data producers and data archives in the earth system sciences, the health and biological research communities.
+
+The aim is to maximise the usefulness of CF to a wide range of communities, encourage others to join and contribute to the CF community effort, and enhance interoperability with other widely used standards.
+The desired outcome is a publication of the proceedings, including a roadmap for development of the CF conventions and vocabularies over the next 1 to 5 years.
+
+Part 2 will follow the familiar format of our usual annual meeting.
+
+**If you are interested in helping to set the meeting agenda, please [comment on this issue][ISSUE], or even join the organising committee (there's still room for more help!)**
+
+## Documents
+
+All the presentations and notes for the plenary and breakout sessions will be available in this [Google Drive folder]() (No yet availiable).
+
+## Agenda
+**TO BE [DISCUSSED][ISSUE] AND COMPLETED**
+
+### Tuesday, 17 September 2024
+
+#### Day 1 of 2: Engaging the cross-domain CF community to gather user needs and develop a high-level CF roadmap.
+TBC
+
+### Wednesday, 18 September 2024
+
+#### Day 2 of 2: Engaging the cross-domain CF community to gather user needs and develop a high-level CF roadmap.
+TBC
+
+### Thursday, 19 September 2024
+#### Day 1 of 2: Detailed CF development including hackathon sessions.
+TBC
+
+### Friday, 20 September 2024
+#### Day 2 of 2: Detailed CF development including hackathon sessions.
+TBC
+
+## CF Code of Conduct
+Participants should review the [CF Code of Conduct][CoC].
+
+## The organising committee
+* Alison Pamment
+* David Hassell
+* Elli Fisher
+* Ethan Davis
+* Lars Bärring
+* **Your name here, [there's still room for more help!][ISSUE]**
+
+[ISSUE]: https://github.com/cf-convention/discuss/issues/279
+[CoC]: https://github.com/cf-convention/cf-conventions/blob/main/CODE_OF_CONDUCT.md

--- a/Meetings/index.md
+++ b/Meetings/index.md
@@ -8,6 +8,7 @@ group: "navigation"
 
 ## Annual CF Workshops
 
+* **[2024 CF Workshop][2024] - 17-20 September 2024 - SMHI - Norrköping (Sweden)**
 * [2023 CF Workshop][2023] - 3-5 October 2023 - Virtual Workshop
 * [2022 CF Workshop][2022] - 13-15 September 2022 - IFCA (CSIC-UC) - Santander (Spain)
 * [2021 CF Workshop][2021] - 21-23 September 2021 - Virtual Workshop
@@ -17,6 +18,7 @@ group: "navigation"
 * [2017 Advancing netCDF-CF Workshop][2017] - 6-8 September 2017 - EarthCube - Boulder, CO (USA)
 * [2016 Advancing netCDF-CF Workshop for the Geosciences][2016] - 24-26 May 2016 - EarthCube - Boulder, CO (USA)
  
+[2024]: 2024-Workshop.html
 [2023]: 2023-Workshop.html
 [2022]: 2022-Workshop.html
 [2021]: 2021-Workshop.html


### PR DESCRIPTION
I have just added the skeleton page for the forthcoming 2024 CF Workshop. 

@larsbarring please, can you review it?


