### PR TITLE
Software page: updates regarding cf-view & cf-plot packages

### DIFF
--- a/software.md
+++ b/software.md
@@ -47,14 +47,14 @@ Field constructs from cf can also be visualised with the [cf-plot package](#cf-p
 
 ### cf-plot - CF Python Plotting package
 
-cf-plot is a set of Python functions for making common contour, vector and line plots that climate researchers use.
+[cf-plot](https://ncas-cms.github.io/cf-plot/build/) is a set of Python functions for making common contour, vector and line plots that climate researchers use.
 cf-plot generally uses [cf-python](#cf-python---cf-python-package) to present the data and CF attributes for plotting.
 It can also use numpy arrays of data as the input fields making for flexible plotting of data.
 cf-plot uses the Python numpy, matplotlib and scipy libraries.
 
 ### cf-view - CF Python Quick Look Visualization Package
 
-The [cf-view Python package](https://ajheaps.github.io/cf-view/) is a quick look data exploration tool for netCDF and Met Office PP data.
+The [cf-view Python package](https://ncas-cms.github.io/cf-view/build/) is a quick look data exploration tool for netCDF and Met Office PP data.
 It uses the [cf-python](#cf-python---cf-python-package) and [cf-plot](#cf-python---cf-python-package) packages and reads and writes CF-compliant dataset.
 
 ### ERDDAP - scientific data server

--- a/software.md
+++ b/software.md
@@ -47,15 +47,11 @@ Field constructs from cf can also be visualised with the [cf-plot package](#cf-p
 
 ### cf-plot - CF Python Plotting package
 
-[cf-plot](https://ncas-cms.github.io/cf-plot/build/) is a set of Python functions for making common contour, vector and line plots that climate researchers use.
-cf-plot generally uses [cf-python](#cf-python---cf-python-package) to present the data and CF attributes for plotting.
-It can also use numpy arrays of data as the input fields making for flexible plotting of data.
-cf-plot uses the Python numpy, matplotlib and scipy libraries.
+The [cf-plot Python package](https://ncas-cms.github.io/cf-plot/build/) supports the production and customization of publication-quality contour, vector, line and more plots using matplotlib, Cartopy and [cf-python](#cf-python---cf-python-package), in as few lines of code as possible.
 
-### cf-view - CF Python Quick Look Visualization Package
+### cf-view - CF Python Exploration and Visualization Package
 
-The [cf-view Python package](https://ncas-cms.github.io/cf-view/build/) is a quick look data exploration tool for netCDF and Met Office PP data.
-It uses the [cf-python](#cf-python---cf-python-package) and [cf-plot](#cf-python---cf-python-package) packages and reads and writes CF-compliant dataset.
+The [cf-view Python package](https://ncas-cms.github.io/cf-view/build/) is a Graphical User Interface (GUI) for earth science and aligned research which supports the exploration, analysis and plotting of netCDF and Met Office format (PP or fields) data. It uses the [cf-python](#cf-python---cf-python-package) and [cf-plot](#cf-python---cf-python-package) packages.
 
 ### ERDDAP - scientific data server
 

--- a/software.md
+++ b/software.md
@@ -51,7 +51,7 @@ The [cf-plot Python package](https://ncas-cms.github.io/cf-plot/build/) supports
 
 ### cf-view - CF Python Exploration and Visualization Package
 
-The [cf-view Python package](https://ncas-cms.github.io/cf-view/build/) is a Graphical User Interface (GUI) for earth science and aligned research which supports the exploration, analysis and plotting of netCDF and Met Office format (PP or fields) data. It uses the [cf-python](#cf-python---cf-python-package) and [cf-plot](#cf-python---cf-python-package) packages.
+The [cf-view Python package](https://ncas-cms.github.io/cf-view/build/) is a Graphical User Interface (GUI) for earth science and aligned research which supports the exploration, analysis and plotting of netCDF and Met Office format (PP or fields) data. It uses the [cf-python](#cf-python---cf-python-package) and [cf-plot](#cf-plot---cf-plot-package) packages.
 
 ### ERDDAP - scientific data server
 


### PR DESCRIPTION
I have recently moved the canonical (working, i.e. being updated as-and-when) location documentation for cf-plot and cf-view from the domain `https://ajheaps.github.io/`, corresponding to hosting under the GitHub user `ajheaps`, to the domain `https://ncas-cms.github.io/` for the user `NCAS-CMS`, after the retirement of our colleague Andy Heaps, who previously managed and hosted thee under his own user space. We wanted these hosted under the NCAS-CMS space in line with our other CF Data Tools libraries (cf-python, cfdm, etc.).

This PR is therefore to update those links. I have also updated the associated summaries in-line with revised straplines (one-sentence summaries) of the libraries, as per the READMEs for the repos in question.

Reviewer(s), if you could please confirm the links work and show the equivalent documentation as the old link, keeping in mind that the new link will get updated whereas the old ones will not be, so there may already be slight differences. Andy is enjoying retirement so probably is not available to confirm/approve this move, but if you want confirmation of the circumstances above feel free to check with NCAS-CMS colleagues, e.g. David Hassell or Ros Hatcher who are involved with CF.