### PR TITLE
Refactor pages build and publish workflow

### DIFF
--- a/.github/workflows/build_and_deploy_web.yml
+++ b/.github/workflows/build_and_deploy_web.yml
@@ -1,0 +1,72 @@
+#
+# GitHub Actions Workflow to build and deploy CF Website.
+#
+# For more information on the actions used in this workflow, please see:
+#   https://github.com/actions/checkout
+#   https://github.com/marketplace/actions/build-jekyll
+#   https://github.com/actions/deploy-pages
+#
+name: Build and Deploy CF Website
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+    contents: write
+    pages: write
+    id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+    group: "pages"
+    cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+    
+#      - name: Setup Pages
+#        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll 
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+
+#      - name: Touch .nojekyll
+#        run: |
+#          sudo touch _site/.nojekyll
+#          sudo chmod -R a+rX _site
+  
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: _site # The folder the action should deploy.
+          branch: gh-pages # The branch to deploy to
+          clean: true
+          clean-exclude: |
+            .nojekyll
+
+#      - name: Upload artifact
+#        uses: actions/upload-pages-artifact@v3
+#        with:
+#          path: ./_site
+#
+#  deploy:
+#    runs-on: ubuntu-latest
+#    needs: build
+#    steps:
+#      - name: Deploy to GitHub Pages
+#        id: deployment
+#        uses: actions/deploy-pages@v4
+#    environment:
+#      name: github-pages
+#      url: ${{ steps.deployment.outputs.page_url }}
+

--- a/.github/workflows/check_links_cron.yml
+++ b/.github/workflows/check_links_cron.yml
@@ -3,7 +3,7 @@
 #
 # For more information on the actions used in this workflow, please see:
 #   https://github.com/lycheeverse/lychee-action
-#   https://github.com/actions/download-artifact
+#   
 #   https://github.com/micalevisk/last-issue-action
 #   https://github.com/peter-evans/create-issue-from-file
 #   https://github.com/marketplace/actions/create-or-update-comment
@@ -21,12 +21,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout main branch
         uses: actions/checkout@v4
+        with:
+          ref: main      # main branc contains link check config
 
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
- 
+#      - name: Build with Jekyll
+#        uses: actions/jekyll-build-pages@v1
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages      # page is already build and deployed from this branch
+          path: _site/       # checkout to default jekyll ouput directory
+  
       - name: Check CF site's links 
         id: check-links
         uses: lycheeverse/lychee-action@v1
@@ -39,6 +47,9 @@ jobs:
           args: --config .lychee/config.toml ./_site/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GitHub API token to use when checking github.com links, to avoid rate limiting
+
+      - name: Add section to the end of report
+        run: sed -i 's/\[Full Github Actions output\]/\n## &/g' .lychee/results.md
 
       - name: Find the last report issue
         id: last-issue
@@ -59,6 +70,13 @@ jobs:
           labels: |
             defect, link-checker,  report, automated issue     
 
+      - name: If failure and issue is closed, reopen and comment
+        if: ${{ steps.check-links.outcome == 'failure' && steps.last-issue.outputs.is-closed == 'true' }}
+        run: gh issue reopen $ISSUE --comment "Broken links detected in CF Website, reopen issue"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ steps.last-issue.outputs.issue-number }}
+              
       - name: If failure and issue exists, add comment 
         if: ${{ steps.check-links.outcome == 'failure' && steps.last-issue.outputs.has-found == 'true' }}
         uses: peter-evans/create-or-update-comment@v4


### PR DESCRIPTION
I have made this change to check links in actual deployed CF page, instead of re-build page from source, every time CRON check links runs. 

1. The CF page, now it's been build from source, and the resulting site files are committed to the `gh-pages` branch, which it's been use by GH to deploy the actual page. 

2. The check actions, download the build page from `gh-pages` branch and check links on contents already build on step 1. 

