### PR TITLE
Exclude GDT to be link checked

### DIFF
--- a/.lychee/config.toml
+++ b/.lychee/config.toml
@@ -32,4 +32,5 @@ exclude_path = [
     "_site/Data/cf-standard-names/docs/guidelines.html",
     "_site/Data/cf-conventions/",
     "_site/Data/Trac-tickets/",
+    "_site/GDT/", # some HTML docs are invalid input encoded, choking the link checker
 ]


### PR DESCRIPTION
Some GDT documents have an invalid input encoding, that makes web link checker exit with an error