### PR TITLE
CF Workshop 2024 page: fix typo in talk name

### DIFF
--- a/Meetings/2024-Workshop.md
+++ b/Meetings/2024-Workshop.md
@@ -98,7 +98,7 @@ For the second part the overall aim is to have a dynamic and flexible agenda tha
       <td>
         &emsp;Chair: Alison Pamment&emsp;<br/>
         &emsp;<em>Keynote: Stuart Chalk (virtual): Digital Units of Measurement: The Digital SI and Interoperable Units</em>&emsp;<br/>
-        &emsp;<em>Keynote: Chris Little (virtual): OGC Temporal Doman Working Group Activities</em>&emsp;
+        &emsp;<em>Keynote: Chris Little (virtual): OGC Temporal Domain Working Group Activities</em>&emsp;
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Following along with the agenda during the workshop today I noticed a typo. It's a trivial one-word change and whilst elsewhere I'd push it straight to upstream as a lone commit instead of raising a PR, I don't want to bypass our workflows, so please can someone approve and merge? Thanks.