### PR TITLE
Putting in quarantine new links errors

### DIFF
--- a/.lychee/config.toml
+++ b/.lychee/config.toml
@@ -27,6 +27,7 @@ exclude = [
     "https://figshare.com/account/articles/24633894",     # 2023-Workshop
 #    "https://github.com/",                               # Uncomment if you hit GitHub Rate Limit: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
 ### QUARANTINE
+     "https://coastwatch.pfeg.noaa.gov/erddap/convert/units.html", # faq
      "https://github.com/orgs/cf-convention/projects/1",    # Meetings/2020-Workshop.md
      "Data/cf-standard-names/current/build/kwic_index_for_cf_standard_names.html", # vocabularies (temporal issue with KWIC generator)
      "Data/cf-standard-names/86/build/kwic_index_for_cf_standard_names.html", # vocabularies (temporal issue with KWIC generator)

--- a/.lychee/config.toml
+++ b/.lychee/config.toml
@@ -26,6 +26,12 @@ exclude = [
     "https://figshare.com/account/articles/24633939",     # 2023-Workshop
     "https://figshare.com/account/articles/24633894",     # 2023-Workshop
 #    "https://github.com/",                               # Uncomment if you hit GitHub Rate Limit: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+### QUARANTINE
+     "https://github.com/orgs/cf-convention/projects/1",    # Meetings/2020-Workshop.md
+     "Data/cf-standard-names/current/build/kwic_index_for_cf_standard_names.html", # vocabularies (temporal issue with KWIC generator)
+     "Data/cf-standard-names/86/build/kwic_index_for_cf_standard_names.html", # vocabularies (temporal issue with KWIC generator)
+### 
+
 ]
 exclude_path = [
     # Jekyll post build directory (i.e. _site)


### PR DESCRIPTION
The version 86 of standard names tables has some issues generating the KWIC file format.
The GITHUB project feature has been deleted from the CF-Conventions
