### PR TITLE
Add EF to authors for 2020-Workshop.md

### DIFF
--- a/Meetings/2020-Workshop.md
+++ b/Meetings/2020-Workshop.md
@@ -110,4 +110,4 @@ Thanks for their support is extended to to:
 
 Jim Biard, Dave Blodgett, Kevin O'Brien, Antonio Cofiño, Ethan Davis,
 David Hassell, Jessica Hausman, Aleksandar Jelenak, Daniel Lee,
-Jonathan Yu
+Jonathan Yu (ELLIE FISHER TEST)


### PR DESCRIPTION
Testing pushing changes to the CF website through GitHub pages (Good Housekeeping session CF workshop 2024).