### PR TITLE
Flash message added to home page of Open Science Recognition Prize

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,10 +25,43 @@
         padding-bottom: 20px;
       }
       p a.anchor {
-        display: block; 
+        display: block;
         position: relative;
-        top: -50px; 
+        top: -50px;
         visibility: hidden;
+      }
+    </style>
+    <style>
+      .flash-message {
+        padding: 1em;
+        margin-bottom: 1em;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        text-align: center;
+      }
+
+      .flash-info {
+        background-color: #d9edf7;
+        color: #31708f;
+        border-color: #bce8f1;
+      }
+
+      .flash-success {
+        background-color: #dff0d8;
+        color: #3c763d;
+        border-color: #d6e9c6;
+      }
+
+      .flash-warning {
+        background-color: #fcf8e3;
+        color: #8a6d3b;
+        border-color: #faebcc;
+      }
+
+      .flash-error {
+        background-color: #f2dede;
+        color: #a94442;
+        border-color: #ebccd1;
       }
     </style>
   </head>
@@ -58,6 +91,11 @@
       </div>
     </div>
 
+    {% if page.flash_message %}
+    <div class="flash-message flash-{{ page.flash_message_type | default: 'info' }}">
+      {{ page.flash_message }}
+    </div>
+    {% endif %}
     <!-- Main jumbotron for a primary marketing message or call to action -->
 
     <div class="container">
@@ -81,7 +119,7 @@
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>    
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
     <script src="{{ '/Data/media/js/links.js' | relative_url }}"></script>
 
   </body>

--- a/index.md
+++ b/index.md
@@ -1,12 +1,14 @@
 ---
 layout: default
 title: CF Conventions Home Page
+flash_message: "The CF Conventions have won the <a href='https://www.agu.org/user-profile?cstkey=0fc4a399-6049-4787-8dc4-c57c91b8a26f' target='_blank'>AGU Open Science Recognition Prize</a> for 2024! 🎉"
+flash_message_type: "success"  # Optional: Use 'info', 'success', 'warning', or 'error'
 ---
 
 # CF Metadata Conventions
 
-The CF metadata conventions are designed to promote the processing and sharing of files created with the [NetCDF API][api]. 
-The conventions define metadata that provide a definitive description of what the data in each variable represents, and the spatial and temporal properties of the data. 
+The CF metadata conventions are designed to promote the processing and sharing of files created with the [NetCDF API][api].
+The conventions define metadata that provide a definitive description of what the data in each variable represents, and the spatial and temporal properties of the data.
 This enables users of data from different sources to decide which quantities are comparable, and facilitates building applications with powerful extraction, regridding, and display capabilities.
 The CF convention includes a standard name table, which defines strings that identify physical quantities.
 
@@ -24,7 +26,7 @@ The CF convention includes a standard name table, which defines strings that ide
 CF is developed through open discussion on GitHub.
 If you would like to propose a change, make a suggestion, report a problem or ask a question, please [see here][discussion].
 Changes are decided according to the CF [governance arrangements][governance].
-The CF community embraces a philosophy of producing excellence by maintaining an open and welcoming culture and an environment that promotes debate and inquiry in a respectful, bold and intellectually rigorous fashion. 
+The CF community embraces a philosophy of producing excellence by maintaining an open and welcoming culture and an environment that promotes debate and inquiry in a respectful, bold and intellectually rigorous fashion.
 
 Initially CF was developed for gridded data from climate and forecast models (hence "CF") of the atmosphere and ocean, but its use has subsequently extended to other geosciences, and to observations as well as numerical models.
 The use of CF is recommended where applicable by Unidata.


### PR DESCRIPTION
To address this issue:
https://github.com/cf-convention/cf-convention.github.io/issues/551

I have added a flash message to the top of the home page to state that CF have won the AGU Open Science Recognition Prize.

![image](https://github.com/user-attachments/assets/1b60333b-9cfb-482d-a947-58e30e6f8d38)

I have done this using flash messages that can be added in the header of any of the markdown pages.

Flash messages should be temporary, so this should be updated when we have something new to say. Perhaps advertising the CF workshop for example. If we want a more permanent place for adding a log of prizes won, this still needs to be developed.