### PR TITLE
Add notes from all CF Info Mgmt and Support Team meetings to date.

### DIFF
--- a/Governance/InfoMgmt/2024-03-11-meeting.md
+++ b/Governance/InfoMgmt/2024-03-11-meeting.md
@@ -1,0 +1,53 @@
+---
+layout: default
+title: 2024-03-11 CF Information Management and Support Team meeting
+---
+# 2024-03-11 CF Information Management and Support Team meeting
+
+## Attendees
+Andrew Barna, Sadie Bartholomew, Antonio S. Cofiño, Francesca Eggleton, Ellie Fisher, David Hassell, Rosalyn Hatcher, Alison Pamment, Daniel Lee, Jonathan Gregory
+
+## Agenda/Notes
+
+* Decide on how often to hold regular meetings of the info-mgmt team
+    * Quarterly
+* Schedule next meeting of the info-mgmt team
+    * Wednesday 5 June 2024 at 15:00 UTC
+* How to communicate as team? emails, other?
+    * GH Team Discussions were sunset (see [GH blog post](https://github.blog/changelog/2023-02-08-sunset-notice-team-discussions/) announcement)
+    * Email
+* Initial (test) migration to GH Discussions instead of CF Discuss issues
+    * See issue #[440](https://github.com/cf-convention/cf-conventions/issues/440) and Gov Panel notes from Dec 2023 mtg
+    * Test setup announcement by Jonathan (see Issue #[290](https://github.com/cf-convention/discuss/issues/290) and Discussion #[289](https://github.com/orgs/cf-convention/discussions/289)).
+    * Fran - tested GH Discussions - would like to demonstrate some potential problems
+    * Changes to website and templates for new issues
+    * Can discussions be made into issues in other repos? Need to test.
+    * Do we even want to create issue from discussion topic?
+        * Or summarize agreed issue in new Issue.
+    * See “Reference in new issue” option in Discussion comment menu option
+    * Actions:
+        * All: More testing
+        * Jonathan: summarize this discussion in Discussion forum
+* New (renamed) CF Standard Names repo
+    * Discuss new repo (transfer SN Issues) vs renaming discuss (transfer non SN into Discussions)
+    * Two pieces:
+        * Documents, etc. that want to store/track in git
+        * Discussion
+    * Alison: no need to move standard name docs out of website repo
+    * Ethan: DOIs might be easier; website space issues
+    * Alison: How to re-architect how standard names are handled in GH?
+
+## Hold for next meeting
+
+* Build/release process
+    * Can we control the files archived during a release?
+        * For instance, PDF and HTML.zip instead of .zip of repo contents?
+* Suppress output from link checker if there are no problems to report
+
+## Hold for separate (or next) meeting
+
+* DOI and License
+    * Add license information to header/footer of web pages (issue \#?)
+    * Add license information to CF Conventions docs, HTML and PDF (issue \#?)
+* Author/contributor lists
+    * Goal: One machine readable copy used to auto-generate lists in docs

--- a/Governance/InfoMgmt/2024-03-11-meeting.md
+++ b/Governance/InfoMgmt/2024-03-11-meeting.md
@@ -47,7 +47,7 @@ Andrew Barna, Sadie Bartholomew, Antonio S. Cofiño, Francesca Eggleton, Ellie F
 ## Hold for separate (or next) meeting
 
 * DOI and License
-    * Add license information to header/footer of web pages (issue \#?)
+    * Add license information to header/footer of web pages (issue https://github.com/cf-convention/cf-convention.github.io/issues/116)
     * Add license information to CF Conventions docs, HTML and PDF (issue \#?)
 * Author/contributor lists
     * Goal: One machine readable copy used to auto-generate lists in docs

--- a/Governance/InfoMgmt/2024-03-11-meeting.md
+++ b/Governance/InfoMgmt/2024-03-11-meeting.md
@@ -48,6 +48,6 @@ Andrew Barna, Sadie Bartholomew, Antonio S. Cofiño, Francesca Eggleton, Ellie F
 
 * DOI and License
     * Add license information to header/footer of web pages (issue https://github.com/cf-convention/cf-convention.github.io/issues/116)
-    * Add license information to CF Conventions docs, HTML and PDF (issue \#?)
+    * Add license information to CF Conventions docs, HTML and PDF (issue https://github.com/cf-convention/cf-convention.github.io/issues/182)
 * Author/contributor lists
     * Goal: One machine readable copy used to auto-generate lists in docs

--- a/Governance/InfoMgmt/2024-06-05-meeting.md
+++ b/Governance/InfoMgmt/2024-06-05-meeting.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: 2024-06-05 CF Information Management and Support Team meeting
+---
+# 2024-06-05 CF Information Management and Support Team meeting
+
+## Attending
+Jonathan Gregory, Ethan Davis, Andrew Barna, Sadie Bartholomew, Francesca Eggleton, David Hassell, Gui Castelao, Alison Pamment, Antonio S. Cofiño
+
+## Agenda/Notes
+
+* Schedule next meeting of the info-mgmt team
+    * 3 Sept at 15:00 UTC
+* Review [notes](2024-03-11-meeting.md) from last meeting (11 March), for agenda items for this meeting
+* Link Checker: Discussion #[320](https://github.com/orgs/cf-convention/discussions/320) “Broken web links”
+    * \[Antonio\]: Re-open issue on error?
+    * \[Antonio\]: After error, report “no-error” status and close issue automatically?
+        * Jonathan suggests only open on error, close by hand.
+        * **Decision**: Open automatically, close manually.
+    * \[Antonio\]: Long action: Check and take actions on excluded paths and/or links
+        * **Decision**: Repost broken links that we know that they are definitely broken/missing
+* Should CF info-mgmt team meetings be open and advertised in CF Discussion?
+    * Ask for input on agenda items in the announcement?
+    * Publish Agenda/Notes or minutes?
+        * Stick with GDocs? On CF website? On CF GitHub Wiki?
+    * Discuss:
+        * Alison: advertise agenda ahead of time, open if interested.
+        * David: discussed in conventions meeting \- announce and invite if interested (email for meeting link)
+        * Gui: agree, maybe not expressly invite unless requested, just to not slow things down too much.
+        * Andrew: are issues opened on all topics we discuss.
+        * Alison: Do we need process to track issues that should be discussed here.
+        * Sadie: Could we use a label(s) to indicate
+        * David: voting should be team members only
+        * **Decision**: advertise agenda ahead of time. (issue/discuss/wiki?). Discussion “announce” tag.
+            * Allow external participants if requested.
+* Review new DOIs for CF Conventions document and the DOI metadata
+    * **Decision**: Build/release process should add PDF (and HTML ?) files to GitHub Release
+    * Metadata
+    * **Action**: Add DOI to CITATION.CFF
+    * **Action**: Review .zenodo.json, compare to DOI metadata
+
+## Hold for next meeting
+
+* CF Conventions document build draft/release process
+    * Draft versions need to be clarified that “CF-\<version\>-draft” is not valid in ‘Conventions’ attribute (See Discussion \#[321](https://github.com/orgs/cf-convention/discussions/321))
+* Author/contributor lists
+    * Goal: One machine-readable copy used to auto-generate lists in docs

--- a/Governance/InfoMgmt/2024-09-03-meeting.md
+++ b/Governance/InfoMgmt/2024-09-03-meeting.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: 2024-09-03 CF Information Management and Support Team meeting
+---
+# 2024-09-03 CF Information Management and Support Team meeting
+
+## Attendees
+Andrew Barna, Lars Bärring, Guilherme Castelao, Antonio S. Cofiño, Ethan Davis, Francesca Eggleton, Ellie Fisher, Jonathan Gregory, Daniel Lee, Alison Pamment
+
+## Agenda/Notes
+
+* Schedule next meeting of the info-mgmt team
+    * 3rd Dec at 15:00 UTC
+* CF Workshop hackathon planning
+* GH Permissions: CF org members, teams, permissions, external collaborators
+    * **Decisions:**
+        * \[**Done**\] Delete ‘conventions’ and ‘Web’ teams
+        * \[**Done**\] Remove a few no longer active members from organization
+        * Review content and make ‘cf-training’ repo public. Consider folding into web site.
+        * \[**Done**\] Remove webtest1 repo
+        * \[**Done**\] Downgrade info-mgmt to ‘maintenance’ from ‘admin’
+        * \[**Done**\] Give committees and panel Write permission
+        * \[**Done**\] Owners: good with the current three (Ethan, David, Daniel)
+        * \[**Done**\] Change ‘Contributor’ team name to “Moderator’
+    * Collaborator role:
+        * Moderator role (for issues) needs permissions to modify/edit the initial post.
+        *
+* CF Conventions document build draft/release process
+    * Draft versions need to be clarified that “CF-\<version\>-draft” is not valid in ‘Conventions’ attribute (See Discussion \#[321](https://github.com/orgs/cf-convention/discussions/321))
+    * Agreement reached, we think. Issue and PR needed
+* Author/contributor lists
+    * Goal: One machine-readable copy used to auto-generate lists in docs
+    * Possible Hackathon topic?
+* The following three open conventions issues are all technical matters, and they have stalled.
+  Would anyone volunteer to adopt any of them?
+  (Sadie opened the first two, but that doesn't oblige her to complete them\!)
+    * Color blindness accessibility of document figures & tables (Issue #[404](https://github.com/cf-convention/cf-conventions/issues/404))
+    * Appendix F: 14 geotiff.maptools.org domain links redirecting (Issue #[479](https://github.com/cf-convention/cf-conventions/issues/479))
+    * Formatting of local links in text; Lists of Figures, Tables and Examples (Issue #[499](https://github.com/cf-convention/cf-conventions/issues/499))
+* At its meeting today, the committee thought it would be useful to have some very short and simple instructions about how to "check and merge a PR", if requested to do so.
+  The "check" part means casting your eye over it, just to see that it changes the files in reasonable ways, doesn't delete any files unexpectedly or cause other accidental damage.
+  It doesn't mean checking the content beyond that, because we don't merge until the content has been agreed in detail. 
+  There are some committee members who might do this when requested, but don't know how.
+* Issue #[151](https://github.com/cf-convention/cf-conventions/issues/151) on moderation of proposals contains some agreement that it would be a good idea for moderators of proposals to be able to update the initial posting in an issue, to add links to summaries or key points in the discussion.
+  To update someone else's post requires write permission to the repo, which not everyone has.
+  Would it be reasonable and practical to give write permission to the conventions repo to anyone who volunteers as a moderator?

--- a/Governance/InfoMgmt/2024-12-03-meeting.md
+++ b/Governance/InfoMgmt/2024-12-03-meeting.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: 2024-12-03 CF Information Management and Support Team meeting
+---
+# 2024-12-03 CF Information Management and Support Team meeting
+
+## Attendees
+???
+
+## Agenda/Notes
+
+* Schedule next meeting
+    * 4 March 2025 8am Mtn
+* Vocabularies repo structure (Andrew Barna, Jonathan Gregory(?))
+    * Test Repo: https://github.com/DocOtak/cf-vocabularies/tree/reorg
+    * Some Proposal Text: https://github.com/DocOtak/cf-vocabularies/blob/reorg/proposal_structure.md
+    * Demo Site: https://www.andrewbarna.org/cf-vocabularies/
+    * Proposal is 254MB (vs 781 in existing website Data dir)
+* Two outstanding technical conventions issues. Does anyone have time to address them?
+    * Color blindness accessibility of document figures & tables - Issue #[404](https://github.com/cf-convention/cf-conventions/issues/404)
+    * Appendix F: 14 geotiff.maptools.org domain links redirecting - Issue #[479](https://github.com/cf-convention/cf-conventions/issues/479)
+* Comparison of GitHub Discussions with Discuss issues, now we’ve got experience of both.
+* \[Antonio\] Review and Finalization of PR \#570 and v1.12 Zenodo SANDBOX Process
+    * Objective: Discuss the current state of PR \#[570](https://github.com/cf-convention/cf-conventions/pull/570)   
+      which includes colophon, license, citation, and DOI. Determine any final changes or approvals needed for the draft before the "final final" release.
+    * Review the Zenodo SANDBOX publication process challenges outlined in the [comment](https://github.com/orgs/cf-convention/discussions/326#discussioncomment-11441829) to discussion \#326.
+        * CF Metadata Conventions \- SANDBOX Zenodo Community
+            * https://sandbox.zenodo.org/communities/cfconventions-sandbox
+        * Zenodo SANDBOX record for the CF Conventions Document:
+            * https://sandbox.zenodo.org/records/138825
+    * Plan next steps for addressing issues with earlier versions (v1.0 to v1.11).
+    * Confirm actions required to transition from the Zenodo SANDBOX to the production Zenodo setup.
+    * Specific Task for Ethan: Discuss removing the automatic connection to Zenodo publication during GitHub releases.

--- a/Governance/InfoMgmt/2025-03-04-meeting.md
+++ b/Governance/InfoMgmt/2025-03-04-meeting.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title: 2025-03-04 CF Information Management and Support Team meeting
+---
+# 2025-03-04 CF Information Management and Support Team meeting
+
+## Attendees
+Ethan Davis, Antonio S. Cofiño, Jonathan Gregory, Francesca Eggleton, David Hassell, Sadie Bartholomew, Alison Pamment, Guilherme Castelao, Ellie Fisher
+
+###  Agenda/Notes
+
+* Schedule next meeting
+    * 5 June 2025 at 15:00 UTC (9am MT)
+* Website needs info on how to cite CF
+    * Find and ping current issue ***(David to do)***
+    * Add DOI links to list of CF versions
+    * Add current DOI/citation to front page
+* Vocab repo structure - next step is discussion between Andrew, Fran, Ellie and Alison  
+  Andrew may be out of office until June, Alison to arrange meeting \[“I'll be at sea (or traveling to/from ports) from starting 2025 March 5 to 2025 May 5.” Andrew\]
+* Automate author/contrib list from one source (currently three web lists of different kinds of contributor, cff files and in the CF convention document)
+    * There is already an ISSUE and a PR solving it:
+        * https://github.com/cf-convention/cf-conventions/issues/579
+        * https://github.com/cf-convention/cf-conventions/pull/580
+* Ethan will move meeting notes/minutes into website

--- a/Governance/InfoMgmt/meeting-minutes.md
+++ b/Governance/InfoMgmt/meeting-minutes.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: CF Information Management and Support Team Meeting Minutes
+---
+
+# CF Information Management and Support Team Meeting Minutes
+
+* [2025-03-04 CF Info Mgmt Team Meeting](2025-03-04-meeting.md)
+* [2024-12-03 CF Info Mgmt Team Meeting](2024-12-03-meeting.md)
+* [2024-09-03 CF Info Mgmt Team Meeting](2024-09-03-meeting.md)
+* [2024-06-05 CF Info Mgmt Team Meeting](2024-06-05-meeting.md)
+* [2024-03-11 CF Info Mgmt Team Meeting](2024-03-11-meeting.md)

--- a/Governance/InfoMgmt/template.md
+++ b/Governance/InfoMgmt/template.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: YYYY-MM-DD CF Information Management and Support Team meeting
+---
+# YYYY-MM-DD CF Information Management and Support Team meeting
+
+## Attendees
+
+## Agenda
+
+## Discussion
+
+## Review previous action items
+
+## New Action items
+
+* [ ] (_assigned to_) action item description

--- a/governance.md
+++ b/governance.md
@@ -63,6 +63,8 @@ CF Governance Panel meeting [minutes](Governance/GovPanel/meeting-minutes.md)
 
 Governance Panel members also contribute to information management and support.
 
+CF Information Management and Support Team meeting [minutes](Governance/InfoMgmt/meeting-minutes.md).
+
 ## Acknowledgements
 
 The climate research community is indebted to former members of the committee, panel and team, and to the many other contributors, as listed below, for their magnanimous contributions in establishing and improving the CF Conventions.


### PR DESCRIPTION
Ping @cf-convention/info-mgmt 