### PR TITLE
links to register for workshop

### DIFF
--- a/Meetings/2025-Workshop.md
+++ b/Meetings/2025-Workshop.md
@@ -5,8 +5,12 @@ title: 2025 CF Workshop
 
 # 2025 CF Workshop
 
-The 2025 CF Workshop will be held virtually on 22-25 September 2025.
-The meeting will run for three hours on each day, 15:00 to 18:00 UTC, plus an informal hour at the end of each day.
+The 2025 CF Workshop will be held **virtually** on **22-25 September 2025**.
+The meeting will run for three hours on each day, **15:00 to 18:00 UTC**, plus an informal hour at the end of each day.
+
+## How to register
+
+To participate, please <a href="https://forms.gle/UJ6JCiaZzSGndvWu8" target="_blank">register here.</a>
 
 ## Agenda
 

--- a/Meetings/index.md
+++ b/Meetings/index.md
@@ -8,7 +8,7 @@ group: "navigation"
 
 ## Annual CF Workshops
 
-* [2025 CF Workshop][2025] - 22-25 September 2025 - Virtual Workshop
+* [2025 CF Workshop][2025] - 22-25 September 2025 - Virtual Workshop - <a href="https://forms.gle/UJ6JCiaZzSGndvWu8" target="_blank">register here.</a>
 * [2024 CF Workshop][2024] - 17-20 September 2024 - SMHI - Norrköping (Sweden)
 * [2023 CF Workshop][2023] - 3-5 October 2023 - Virtual Workshop
 * [2022 CF Workshop][2022] - 13-15 September 2022 - IFCA (CSIC-UC) - Santander (Spain)

--- a/index.md
+++ b/index.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: CF Conventions Home Page
-flash_message: "Save the date: The <strong>2025 CF Conventions Workshop</strong> will be hosted online during the week 22nd-26th September! View more details <a href='https://github.com/orgs/cf-convention/discussions/415' target='_blank'>here.</a>"
-flash_message_type: "success"  # Optional: Use 'info', 'success', 'warning', or 'error'
+flash_message: "The <strong>CF Conventions Workshop 2025</strong> will be hosted online from 22nd to 25th September. Register <a href='https://forms.gle/UJ6JCiaZzSGndvWu8' target='_blank'><strong>here</strong></a> and view the agenda <a href='https://cfconventions.org/Meetings/2025-Workshop.html' target='_blank'><strong>here</strong></a>."
+flash_message_type: "info"  # Optional: Use 'info', 'success', 'warning', or 'error'
 ---
 
 # CF Metadata Conventions


### PR DESCRIPTION
I have added a few links to the registration form for the workshop

- On the banner on the home page
- On the workshops main page
- On the 2025 workshop page