### PR TITLE
Convert 2025 workshop page to "pure" markdown

### DIFF
--- a/Meetings/2025-Workshop.md
+++ b/Meetings/2025-Workshop.md
@@ -10,190 +10,58 @@ The meeting will run for three hours on each day, **15:00 to 18:00 UTC**, plus a
 
 ## How to register
 
-To participate, please <a href="https://forms.gle/UJ6JCiaZzSGndvWu8" target="_blank">register here.</a>
+To participate, please [register here](https://forms.gle/UJ6JCiaZzSGndvWu8){:target="_blank"}.
 
 ## Agenda
 
 ### Monday, 22 September 2025
 
-<table>
-<thead>
-<tr>
-<th style="width:20%; text-align:left;">Time (UTC)</th>
-<th style="width:60%; text-align:left;">Session</th>
-<th style="width:20%; text-align:left;">Presenters</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style="text-align:left;">15:00 - 15:10</td>
-<td style="text-align:left;">Welcome and Overview of meeting structure</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">15.10 - 15.40</td>
-<td style="text-align:left;">Introduction to CF, what’s going into CF 1.13</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">15.40 - 15.55</td>
-<td style="text-align:left;"><em>Science talk</em></td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">15.55 - 16.10</td>
-<td style="text-align:left;">Science talk</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">16.10 - 16.25</td>
-<td style="text-align:left;">Screen break / coffee break</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">16.25 - 16.35</td>
-<td style="text-align:left;">Introductions to Day 1 hackathons</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">16:35 - 18.00</td>
-<td style="text-align:left;">HACKATHONS (Parallel sessions)</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">18.00 - 18.45</td>
-<td style="text-align:left;">Social time</td>
-<td style="text-align:left;"></td>
-</tr>
-</tbody>
-</table>
+{: .table .table-bordered}
+| Time (UTC) | Session | Presenters |
+|:-----------|:--------|:-----------|
+|15:00 - 15:10 | Welcome and Overview of meeting structure | |
+|15.10 - 15.40 | Introduction to CF, what’s going into CF 1.13 | |
+|15.40 - 15.55 | *Science talk* | |
+|15.55 - 16.10 | *Science talk* | |
+|16.10 - 16.25 | Screen break / coffee break | |
+|16.25 - 16.35 | Introductions to Day 1 hackathons | |
+|16:35 - 18.00 | HACKATHONS (Parallel sessions) | |
+|18.00 - 18.45 | Social time | |
 
 ### Tuesday, 23 September 2025
 
-<table>
-<thead>
-<tr>
-<th style="width:20%; text-align:left;">Time (UTC)</th>
-<th style="width:60%; text-align:left;">Session</th>
-<th style="width:20%; text-align:left;">Presenters</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style="text-align:left;">15:00 - 15.10</td>
-<td style="text-align:left;">Intro to day 2</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">15.10 - 15.30</td>
-<td style="text-align:left;">Governance updates, round-up of recent developments</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">15.30 - 15.50</td>
-<td style="text-align:left;">Science talk</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">15.50 - 16.00</td>
-<td style="text-align:left;">Introductions to Day 2 hackathons</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">16.10 - 16.25</td>
-<td style="text-align:left;">Screen break / coffee break</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">16:25 - 17.30</td>
-<td style="text-align:left;">HACKATHONS (Parallel sessions)</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">17.30 - 18.00</td>
-<td style="text-align:left;">Day 1 and 2 hackathon wrap-ups</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">18.00 - 18.45</td>
-<td style="text-align:left;">Social time</td>
-<td style="text-align:left;"></td>
-</tr>
-</tbody>
-</table>
+{: .table .table-bordered}
+| Time (UTC) | Session | Presenters |
+|:-----------|:--------|:-----------|
+|15:00 - 15.10| Intro to day 2 | |
+|15.10 - 15.30| Governance updates, round-up of recent developments | |
+|15.30 - 15.50| *Science talk* | |
+|15.50 - 16.00| Introductions to Day 2 hackathons | |
+|16.10 - 16.25| Screen break / coffee break | |
+|16:25 - 17.30| HACKATHONS (Parallel sessions) | |
+|17.30 - 18.00| Day 1 and 2 hackathon wrap-ups | |
+|18.00 - 18.45| Social time | |
 
 ### Wednesday, 24 September 2025
 
-<table>
-<thead>
-<tr>
-<th style="width:20%; text-align:left;">Time (UTC)</th>
-<th style="width:60%; text-align:left;">Session</th>
-<th style="width:20%; text-align:left;">Presenters</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style="text-align:left;">15.00 - 16.00</td>
-<td style="text-align:left;">Roadmap introduction / recap <br> (What is the roadmap? Why do we need it? Which communities are we engaging with? What did we do last year?)</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">16.00 - 16.10</td>
-<td style="text-align:left;">Introductions to Day 3 (roadmap) hackathons</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">16.10 - 16.25</td>
-<td style="text-align:left;">Screen break / coffee break</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">16:25 - 18.00</td>
-<td style="text-align:left;">Roadmap HACKATHONS (Parallel sessions)</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">18.00 - 18.45</td>
-<td style="text-align:left;">Social time</td>
-<td style="text-align:left;"></td>
-</tr>
-</tbody>
-</table>
+{: .table .table-bordered}
+| Time (UTC) | Session | Presenters |
+|:-----------|:--------|:-----------|
+|15.00 - 16.00| Roadmap introduction / recap <br />(What is the roadmap? Why do we need it? Which communities are we engaging with? What did we do last year?)| |
+|16.00 - 16.10 | Introductions to Day 3 (roadmap) hackathons | |
+|16.10 - 16.25 | Screen break / coffee break | |
+|16:25 - 18.00 | Roadmap HACKATHONS (Parallel sessions)| |
+|18.00 - 18.45 | Social time| |
 
 ### Thursday, 25 September 2025
 
-<table>
-<thead>
-<tr>
-<th style="width:20%; text-align:left;">Time (UTC)</th>
-<th style="width:60%; text-align:left;">Session</th>
-<th style="width:20%; text-align:left;">Presenters</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style="text-align:left;">15.00 - 15.15</td>
-<td style="text-align:left;">Introductions to Day 4 (roadmap) hackathons</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">15:15 - 17.00</td>
-<td style="text-align:left;">Roadmap HACKATHONS (Parallel sessions) <br> (includes screen break 16.30 - 16.40)</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">17.00 - 18.00</td>
-<td style="text-align:left;">Roadmap hackathons wrap up and next steps</td>
-<td style="text-align:left;"></td>
-</tr>
-<tr>
-<td style="text-align:left;">18.00 - 18.45</td>
-<td style="text-align:left;">Social time</td>
-<td style="text-align:left;"></td>
-</tr>
-</tbody>
-</table>
+{: .table .table-bordered}
+| Time (UTC) | Session | Presenters |
+|:-----------|:--------|:-----------|
+|15.00 - 15.15| Introductions to Day 4 (roadmap) hackathons||
+|15:15 - 17.00| Roadmap HACKATHONS (Parallel sessions) <br> (includes screen break 16.30 - 16.40)||
+|17.00 - 18.00| Roadmap hackathons wrap up and next steps | |
+|18.00 - 18.45| Social time| |
 
 ## Hackathons
 


### PR DESCRIPTION
Last year at the workshop, when myself or @erget (and I think @cofinoa) were editing the agenda table, having it in html made things a little difficult. Where messing up a closing tag caused the whole page to kinda break.

If folks are interested, this converts that table to be markdown (with some `<br />` tags in the content), it also adds the bootstrap3 table classes so that it renders nicely.