### PR TITLE
Workshop 2025 agenda: add confirmed title for Science Talk

### DIFF
--- a/Meetings/2025-Workshop.md
+++ b/Meetings/2025-Workshop.md
@@ -108,7 +108,7 @@ The organizing committee requests that all presentations, in final form, be plac
 | 15:10--15:40 | Main   | Introduction to CF, what’s going into CF 1.13        |                                               |
 |              |        | &emsp;Introduction                                   | Ellie Fisher (CEDA / NCAS)                    |
 |              |        | &emsp;CF-1.13                                        | Sadie Bartholomew (NCAS / University of Reading) |
-| 15:40--15:55 | Main   | *Science talk:* *TBD*                                | Jack Atkinson (ICCS Cambridge)                |
+| 15:40--15:55 | Main   | *Science talk:* Experiences using cf-python to standardise outputs from cyclone tracking softwares | Jack Atkinson (ICCS Cambridge)               |
 | 15:55--16:10 | Main   | *Science talk:* Evaluating Large Language Models for Standard Names Generation in CF Conventions | Mario Diez Fernandez (University of Cantabria) |
 | 16:10--16:25 | Main   | *Screen break / coffee break*                        |                                               |
 | 16:25--16:35 | Main   | Introductions to Day 1 hackathons                    | *All hackathon chairs*                        |


### PR DESCRIPTION
A trivial change to update a title in the workshop agenda (sorry I was on leave last week so have only just had a chance to update the title confirmed by Jack).

@cf-convention/info-mgmt: please can someone merge this ASAP so it is there in time for the workshop start in less than a few hours! Thanks.