### PR TITLE
Workshop 2025 agenda update to generalise Hackathon name

### DIFF
--- a/Meetings/2025-Workshop.md
+++ b/Meetings/2025-Workshop.md
@@ -96,7 +96,7 @@ The workshop will be held via Zoom.
 
 All the presentations and notes for the plenary and breakout sessions will be available in this [Google Drive folder](https://drive.google.com/drive/folders/1-L_wDQHWM9PaKqUD5AtYNFYsUtbOXSV0).
 
-The organizing committee requests that all presentations, in final form, be placed in a the [CF Metadata Conventions Zenodo Community](https://zenodo.org/communities/cfconventions) document repository that provides permanence for the document and a DOI. If you are new to Zenodo, see the [Zenodo "Quick Start" page](https://help.zenodo.org/docs/get-started/quickstart/).
+The organizing committee requests that all presentations, in final form, be placed in the [CF Metadata Conventions Zenodo Community](https://zenodo.org/communities/cfconventions) document repository that provides permanence for the document and a DOI. If you are new to Zenodo, see the [Zenodo "Quick Start" page](https://help.zenodo.org/docs/get-started/quickstart/).
 
 ## Agenda
 


### PR DESCRIPTION
One final update to the agenda concerning this afternoon's Hackathons, plus a separate typo fix - if it can go in in time (sorry for the short notice, again due to being on leave last week so needing the pre-workshop daytime to prepare a bit).

In short I have generalised the Hackathon I am hosting to reflect the widened scope to accessibility more generally, given some folk have previously requested to discuss further aspects to the figures/tables. No worries if (expected) there isn't time to reflect this title change - I can explain in the introduction to the Hackathon sessions.

@cf-convention/info-mgmt sorry please can someone merge this also - review should take <1 min. Thanks.
