### PR TITLE
Update links to archived Unidata websites 2016 and 2017 CF Workshops and netcdf-java

### DIFF
--- a/Meetings/2016-Workshop.md
+++ b/Meetings/2016-Workshop.md
@@ -11,7 +11,7 @@ title: 2016 CF Workshop
 
 **24-26 May 2016, Boulder, Colorado**
 
-***[Original website hosted at Unidata](https://www.unidata.ucar.edu/events/2016CFWorkshop/ "Unidata's website")***
+***[Original website hosted at Unidata](https://archive.unidata.ucar.edu/events/2016CFWorkshop/ "Unidata's Archive website")***
 
 This workshop will focus on discussing current and future efforts and directions for the Climate and Forecast (CF)
 metadata conventsions for netCDF (netCDF-CF). The meeting will be organized by the “Advancing netCDF-CF for Geoscience”

--- a/Meetings/2017-Workshop.md
+++ b/Meetings/2017-Workshop.md
@@ -11,7 +11,7 @@ title: 2017 CF Workshop
 
 **6-8 September 2017, Boulder, Colorado**
 
-***[Original website hosted at Unidata](https://www.unidata.ucar.edu/events/2017CFWorkshop/ "Unidata's website")***
+***[Original website hosted at Unidata](https://archive.unidata.ucar.edu/events/2017CFWorkshop/ "Unidata's Archive website")***
 
 This workshop will focus on efforts to advance the Climate and Forecast (CF) metadata conventions for
 netCDF (netCDF-CF). The meeting is being hosted by the EarthCube “Advancing netCDF-CF for Geoscience”

--- a/software.md
+++ b/software.md
@@ -93,7 +93,7 @@ The resulting object is logically equivalent to the original, and can be process
 
 ### netCDF-Java Library
 
-The [netCDF Java library](https://www.unidata.ucar.edu/software/netcdf-java/) provides an interface for scientific data access.
+The [netCDF Java library](https://archive.unidata.ucar.edu/software/netcdf-java/) provides an interface for scientific data access.
 It can be used to read scientific data from a variety of file formats including netCDF, HDF, GRIB, BUFR, and many others, as well as a variety of remote data access protocols.
 It implements the [Unidata Common Data Model](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/common_data_model_overview.html) which uses CF and other metadata conventions in its Coordinate System and Scientific Feature Type layers.
 NetCDF-Java can write netCDF-3/4 files that conform to the CF Metadata Conventions.


### PR DESCRIPTION
Update links to archived Unidata websites 2016 and 2017 CF Workshops and netcdf-java
