### PR TITLE
Re-apply #73: Update `rules.md` section on moderation process (after revert #612)

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -14,7 +14,7 @@ The discussion takes place on GitHub issues and all may participate.
 
  1. The moderator, if one has volunteered, should be in charge of the discussion and make sure that it is conducted in a fair and organized way;
  2. The moderator may list major points of agreement and contention, and, if appropriate, provide links to key milestones of the discussion in the top issue of a discussion;
- 3. Participant's in a discussion are expected to respect and comply with requests from the moderator (e.g. to suspend discussion on one topic until another is resolved or to answer specific questions from the moderator). Such requests from the moderator, with appropriate explanations, should be placed in the flow of the discussion.
+ 3. Participants in a discussion are expected to respect and comply with requests from the moderator (e.g. to suspend discussion on one topic until another is resolved or to answer specific questions from the moderator). Such requests from the moderator, with appropriate explanations, should be placed in the flow of the discussion.
  4. The individual acting as moderator may also act as a participant, but should clearly distinguish between the two roles;
  5. The moderator should oversee the implementation of proposed changes which are agreed and close the issue when this process is complete.
 


### PR DESCRIPTION
Updates to guidance notes on the process of moderation, as discussed in #151.

This PR re-applies the changes from #73 after the corrective revert in #612.

Please review the resolution in `rules.md` carefully.

(cherry picked from commit 8e96d48b6bde2d62d41bb376c94d1337dab8be58)

---

### Discussion history (from #73)

Context: updates to the guidance notes on the moderation process discussed in #151 and implemented in #73.

Key comments and reviews:
- @martinjuckes: [Initial proposal and context](https://github.com/cf-convention/cf-convention.github.io/pull/73#issue-483256258)  
  
- @dblodgett-usgs: [Review note about the three-week window](https://github.com/cf-convention/cf-convention.github.io/pull/73#issuecomment-524265978)

#### References:
- Original PR: #73  
- Related discussion: #151