### PR TITLE
Add draft agenda to 2026 CF Workshop page.

### DIFF
--- a/Meetings/2026-Workshop.md
+++ b/Meetings/2026-Workshop.md
@@ -3,6 +3,59 @@ title: "CF Conventions Community Workshop 2026"
 layout: page
 last_checked: 2026-06-30
 ---
+<style>
+/* Same column layout for all agenda tables */
+table.agenda {
+  width: 100%;
+  table-layout: auto; /* let Time/Room size to content */
+}
+
+/* Top-align cells; allow wrapping in text columns */
+table.agenda > thead > tr > th,
+table.agenda > tbody > tr > td {
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+
+/* Col 1: Time — shrink to content, no wrap, centered */
+table.agenda > thead > tr > th:nth-child(1),
+table.agenda > tbody > tr > td:nth-child(1) {
+  white-space: nowrap;
+  width: 1%;              /* shrink-to-fit */
+  text-align: center;
+}
+
+/* Col 2: Room — shrink to content, no wrap, centered */
+table.agenda > thead > tr > th:nth-child(2),
+table.agenda > tbody > tr > td:nth-child(2) {
+  white-space: nowrap;
+  width: 1%;              /* shrink-to-fit */
+  text-align: center;
+}
+
+/* Col 3: Session — wrap, take ~50% of remaining width */
+table.agenda > thead > tr > th:nth-child(3),
+table.agenda > tbody > tr > td:nth-child(3) {
+  width: 50%;
+  text-align: left;
+}
+
+/* Col 4: Presenter/Chair — wrap, take ~50% of remaining width */
+table.agenda > thead > tr > th:nth-child(4),
+table.agenda > tbody > tr > td:nth-child(4) {
+  width: 50%;
+  text-align: left;
+}
+
+/* Small screens: keep layout and allow horizontal scroll if needed */
+@media (max-width: 900px) {
+  table.agenda {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+</style>
 
 # CF Conventions Community Workshop 2026
 
@@ -96,3 +149,83 @@ Sources checked on 30 June 2026:
 
 - <https://events.ecmwf.int/event/568/>
 - <https://climate.copernicus.eu/cf-conventions-community-workshop-2026>
+
+## Draft Agenda
+
+### Day 1 - Monday, 21 September 2026
+
+{: .agenda .table .table-bordered .table-striped}
+| Local Time (Bonn)   | Room   | Session  | Presenter/Chair   |
+|:-------------|:-------|:-----------------------------------------------------|:----------------------------------------------|
+| 13:00 | Main   | Arrivals and coffee |   |
+| 14:00 | Main   | Welcome and Overview of meeting structure  | TBD  |
+| 14:10 | Main   | Introduction to CF |  Jonathan Gregory  |
+|       |        | CF Governance Processes |  Ethan Davis  |
+|       |        | What will be in CF 1.14 | Sadie Bartholomew    |
+| 15:00 | Main   | Coffee break / screen break |  |
+| 15:30 | Main   | Standard names / Vocabularies | Alison Pamment   |
+| 16:00 | Main | Introduction to today's breakout sessions | |
+| 16:10 |      | Breakouts / Hackathons | |
+|       | Room? | CF Profiles, work through with Satellite Swath data | Ethan Davis |
+|       | Room? | Support localization of attribute/variable values | Erin Turnbull (TBC) |
+| 17:30 |       | Adjorn |  |
+| 19:00? | TBD | Workshop dinner |  |
+
+### Day 2 - Tuesday, 22 September 2026
+
+{: .agenda .table .table-bordered .table-striped}
+| Local Time (Bonn)   | Room   | Session  | Presenter/Chair   |
+|:-------------|:-------|:-----------------------------------------------------|:----------------------------------------------|
+| 09:00 | Main   | Coffee and welcome |   |
+| 09:30 | Main   | Uncertainty metadata in CF | David Hassell, Sam Hunt  |
+| 10:00 | Main   | Units of measure in CF and elsewhere | Lars Bärring  |
+| 10:30 | Main   | Coffee break / screen break |  |
+| 11:00 | Main | Introduction to today's breakout sessions | |
+| 11:10 |      | Breakouts / Hackathons | |
+|       | Room? | Uncertainty | David Hassell |
+|       | Room? | BCP 14 | Sadie Bartholemew |
+| 12:30 |        | Lunch break |  |
+| 14:00 | Main   | CF and GRIB (Title?) | Lorea Garcia San Martin, Sébastien Villaume, Pawel ?  |
+| 14:30 | Main   | Implementing CF semantics in BUFR | Mariajana Crepulja |
+| 15:00 | Main   | Coffee break / screen break |  |
+| 15:30 | Main   | World Meteorological Organization CF-NetCDF profiles and governance | David I. Berry, Kevin O'Brien, Bibraj Raj, ??more authors? |
+| 16:00 | Main   | GeoZarr and CF | Max Jones (TBC) |
+| 16:30 | Main   | Implementing CF semantics in Zarr | Patrick van Laake |
+| 17:00 | Main   | Discussion of mappings | |
+| 17:30 |       | Adjorn |  |
+
+### Day 3 - Wednesday, 23 September 2026
+
+{: .agenda .table .table-bordered .table-striped}
+| Local Time (Bonn)   | Room   | Session  | Presenter/Chair   |
+|:-------------|:-------|:-----------------------------------------------------|:----------------------------------------------|
+| 09:00 | Main   | Coffee and welcome |   |
+| 09:30 | Main | Introduction to today's breakout sessions | |
+| 09:40 |      | Breakouts / Hackathons | |
+|       | Room? | Houskeeping | ?? |
+|       | Room? | Standard names for chemical species | Lorea Garcia San Martin |
+| 10:30 | Main   | Coffee break / screen break |  |
+| 11:00 | Main   | Copernicus | Chris Goddard (Has this been confirmed???) |
+| 11:30 | Main   | Plenary - open time slot!!!! | |
+| 12:00 | Main   | CMIP and CORDEX interactinos and use of CF Conventions | Paul Smith (CMIP IPO) |
+| 12:30 |        | Lunch break |  |
+| 14:00 | Main   | Main | WMO Cloud-optimized future data infrastructure | Jeremy Tandy |
+| 14:30 | Main   | Plenary - open time slot!!!! | |
+| 15:00 | Main   | Coffee break / screen break |  |
+| 15:30 | Main   | CF Checkers | IOOS (needs confirmation) + Sadie |
+| 16:00 | Main | Introduction to today's breakout sessions | |
+| 16:10 |      | Breakouts / Hackathons | |
+|       | Room? | Separating CF semantics from netCDF encoding | Patrick van Laake |
+|       | Room? | ??? | ??? |
+| 17:30 |       | Adjorn |  |
+
+### Day 4 - Thursday, 24 September 2026
+
+{: .agenda .table .table-bordered .table-striped}
+| Local Time (Bonn)   | Room   | Session  | Presenter/Chair   |
+|:-------------|:-------|:-----------------------------------------------------|:----------------------------------------------|
+| 09:00 | Main   | Coffee and welcome |   |
+| 09:30 | Main   | Breakout reports |  |
+| 10:30 | Main   | Coffee break / screen break |  |
+| 11:00 | Main   | Wrap-up and Meeting Conclusions |   |
+| 12:30 |        | Adjorn and Lunch |  |

--- a/Meetings/2026-Workshop.md
+++ b/Meetings/2026-Workshop.md
@@ -209,7 +209,7 @@ Sources checked on 30 June 2026:
 | 11:30 | Main   | Plenary - open time slot!!!! | |
 | 12:00 | Main   | CMIP and CORDEX interactinos and use of CF Conventions | Paul Smith (CMIP IPO) |
 | 12:30 |        | Lunch break |  |
-| 14:00 | Main   | Main | WMO Cloud-optimized future data infrastructure | Jeremy Tandy |
+| 14:00 | Main   | WMO Cloud-optimized future data infrastructure | Jeremy Tandy |
 | 14:30 | Main   | Plenary - open time slot!!!! | |
 | 15:00 | Main   | Coffee break / screen break |  |
 | 15:30 | Main   | CF Checkers | IOOS (needs confirmation) + Sadie |


### PR DESCRIPTION
Hi organizing committee - I have added the draft agenda for the workshop. Please review for consistency with our working copy and let me know or push directly if you find problems. I'm going to create this as a draft PR as some things still need to be confirmed (marked TBC or with question marks).

I copied the style and such from the 2025 page. I'm not seeing a full render so it would be great if someone who knew more about it could review the style and such (@lhmarsden ?)

I can only add GH org members as reviewers so a ping to @sebvi (and Lorea?)

Thanks all